### PR TITLE
Add brand and upcharge filter chips to the home screen

### DIFF
--- a/HomeScreen.js
+++ b/HomeScreen.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from "react";
+import React, {useEffect, useMemo, useRef, useState} from "react";
 import {Alert, Animated, Easing, FlatList, Image, Modal, Platform, Share, Text, TouchableOpacity, View,} from "react-native";
 import MapView, {Marker} from "react-native-maps";
 import FreeMapView from "./components/FreeMapView";
@@ -16,6 +16,8 @@ import AdminScreen from "./components/AdminScreen";
 import AdjustPinModal from "./components/AdjustPinModal";
 import ManageShopModal from "./components/ManageShopModal";
 import ShopCard from "./components/ShopCard";
+import ShopFilterBar from "./components/ShopFilterBar";
+import {filterShops, getTopBrands} from "./utils/shopFilters";
 import {getFormattedUpcharge, getUpchargeColor} from "./utils/upchargeEmojis";
 import {getDirections} from "./utils/MapLinks";
 import {getDistanceMeters} from "./utils/GeoUtils";
@@ -283,6 +285,26 @@ export default function HomeScreen() {
   const [favorites, setFavorites] = useState([]);
   const [isOnline, setIsOnline] = useState(true);
   const [isLoadingFromCache, setIsLoadingFromCache] = useState(true);
+  const [brandFilter, setBrandFilter] = useState(null);
+  const [priceFilter, setPriceFilter] = useState(null);
+
+  // Brand chips derived from the loaded shops (no extra Firestore reads,
+  // stays in sync with real-time updates, works offline from cache)
+  const topBrands = useMemo(() => getTopBrands(shops), [shops]);
+
+  // Shops shown on the map and in the list after applying active filters
+  const visibleShops = useMemo(
+    () => filterShops(shops, { brand: brandFilter, priceId: priceFilter }),
+    [shops, brandFilter, priceFilter],
+  );
+  const hasActiveFilters = brandFilter !== null || priceFilter !== null;
+
+  // If the selected shop gets filtered out, close its overlay
+  useEffect(() => {
+    if (selectedShop && !visibleShops.some((shop) => shop.id === selectedShop.id)) {
+      setSelectedShop(null);
+    }
+  }, [visibleShops, selectedShop]);
 
   // Animation values
   const cardOpacity = useRef(new Animated.Value(0)).current;
@@ -848,7 +870,7 @@ export default function HomeScreen() {
               }}
               onPress={(e) => {
                 const tapped = e.nativeEvent.coordinate;
-                const nearby = shops.find((shop) => {
+                const nearby = visibleShops.find((shop) => {
                   const distance = getDistanceMeters(tapped, shop.location);
                   return distance < 100;
                 });
@@ -856,7 +878,7 @@ export default function HomeScreen() {
               }}
               showsUserLocation
               isDark={isDark}
-              markers={shops.map((shop) => ({
+              markers={visibleShops.map((shop) => ({
                 key: shop.id,
                 coordinate: {
                   latitude: shop.location.latitude,
@@ -883,14 +905,14 @@ export default function HomeScreen() {
               }}
               onPress={(e) => {
                 const tapped = e.nativeEvent.coordinate;
-                const nearby = shops.find((shop) => {
+                const nearby = visibleShops.find((shop) => {
                   const distance = getDistanceMeters(tapped, shop.location);
                   return distance < 100;
                 });
                 setSelectedShop(nearby || null);
               }}
             >
-              {shops.map((shop) => (
+              {visibleShops.map((shop) => (
                 <Marker
                   key={shop.id}
                   coordinate={{
@@ -958,11 +980,40 @@ export default function HomeScreen() {
         </View>
       )}
 
+      {shops.length > 0 && (
+        <ShopFilterBar
+          brands={topBrands}
+          selectedBrand={brandFilter}
+          onSelectBrand={setBrandFilter}
+          selectedPriceId={priceFilter}
+          onSelectPrice={setPriceFilter}
+        />
+      )}
+
       <FlatList
-        data={shops}
+        data={visibleShops}
         keyExtractor={(item) => item.id}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={styles.flatListContainer}
+        ListEmptyComponent={
+          hasActiveFilters ? (
+            <View style={styles.filterEmptyState}>
+              <Text style={styles.filterEmptyText}>
+                No shops match your filters
+              </Text>
+              <TouchableOpacity
+                style={styles.filterClearButton}
+                onPress={() => {
+                  setBrandFilter(null);
+                  setPriceFilter(null);
+                }}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.filterClearButtonText}>Clear filters</Text>
+              </TouchableOpacity>
+            </View>
+          ) : null
+        }
         renderItem={({ item }) => (
           <ShopCard
             item={item}

--- a/components/ShopFilterBar.js
+++ b/components/ShopFilterBar.js
@@ -1,0 +1,98 @@
+import React, {useMemo} from 'react';
+import {ScrollView, StyleSheet, Text, TouchableOpacity} from 'react-native';
+import {useTheme} from '../contexts/ThemeContext';
+import {fonts, radius, space} from '../styles/tokens';
+import {PRICE_FILTERS} from '../utils/shopFilters';
+
+/**
+ * Horizontal chip row for filtering shops by upcharge and oat milk brand.
+ * Price chips and brand chips are each single-select toggles; tapping an
+ * active chip clears it. The two filter types compose (brand AND price).
+ */
+const ShopFilterBar = ({
+    brands,
+    selectedBrand,
+    onSelectBrand,
+    selectedPriceId,
+    onSelectPrice,
+}) => {
+    const {colors} = useTheme();
+    const styles = useMemo(() => getStyles(colors), [colors]);
+
+    if ((!brands || brands.length === 0) && PRICE_FILTERS.length === 0) {
+        return null;
+    }
+
+    const renderChip = (key, label, isSelected, onPress) => (
+        <TouchableOpacity
+            key={key}
+            style={[styles.chip, isSelected && styles.chipSelected]}
+            onPress={onPress}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityState={{selected: isSelected}}
+            accessibilityLabel={`Filter: ${label}`}
+        >
+            <Text style={[styles.chipText, isSelected && styles.chipTextSelected]}>
+                {label}
+            </Text>
+        </TouchableOpacity>
+    );
+
+    return (
+        <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.container}
+            keyboardShouldPersistTaps="handled"
+        >
+            {PRICE_FILTERS.map((filter) =>
+                renderChip(
+                    `price-${filter.id}`,
+                    filter.label,
+                    selectedPriceId === filter.id,
+                    () => onSelectPrice(selectedPriceId === filter.id ? null : filter.id)
+                )
+            )}
+            {(brands || []).map((brand) =>
+                renderChip(
+                    `brand-${brand}`,
+                    brand,
+                    selectedBrand === brand,
+                    () => onSelectBrand(selectedBrand === brand ? null : brand)
+                )
+            )}
+        </ScrollView>
+    );
+};
+
+const getStyles = (colors) => StyleSheet.create({
+    container: {
+        paddingHorizontal: space.md,
+        paddingVertical: space.xs,
+        gap: space.xs,
+    },
+    chip: {
+        paddingHorizontal: space.sm,
+        paddingVertical: space.xs,
+        borderRadius: radius.pill,
+        backgroundColor: colors.surfaceMuted,
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+    chipSelected: {
+        backgroundColor: colors.accentSoft,
+        borderColor: colors.accentBorder,
+    },
+    chipText: {
+        fontSize: 13,
+        fontFamily: fonts.medium,
+        color: colors.secondaryText,
+    },
+    chipTextSelected: {
+        color: colors.accent,
+        fontFamily: fonts.semibold,
+    },
+});
+
+export default ShopFilterBar;

--- a/components/ShopFilterBar.js
+++ b/components/ShopFilterBar.js
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react';
 import {ScrollView, StyleSheet, Text, TouchableOpacity} from 'react-native';
 import {useTheme} from '../contexts/ThemeContext';
 import {fonts, radius, space} from '../styles/tokens';
-import {PRICE_FILTERS} from '../utils/shopFilters';
+import {PRICE_FILTERS, ensureBrandIncluded, isSameBrand} from '../utils/shopFilters';
 
 /**
  * Horizontal chip row for filtering shops by upcharge and oat milk brand.
@@ -19,7 +19,14 @@ const ShopFilterBar = ({
     const {colors} = useTheme();
     const styles = useMemo(() => getStyles(colors), [colors]);
 
-    if ((!brands || brands.length === 0) && PRICE_FILTERS.length === 0) {
+    // Keep the active brand renderable even if it drops out of the
+    // top-brands list, so the filter always has a visible, clearable chip
+    const chipBrands = useMemo(
+        () => ensureBrandIncluded(brands, selectedBrand),
+        [brands, selectedBrand],
+    );
+
+    if (chipBrands.length === 0 && PRICE_FILTERS.length === 0) {
         return null;
     }
 
@@ -54,12 +61,12 @@ const ShopFilterBar = ({
                     () => onSelectPrice(selectedPriceId === filter.id ? null : filter.id)
                 )
             )}
-            {(brands || []).map((brand) =>
+            {chipBrands.map((brand) =>
                 renderChip(
                     `brand-${brand}`,
                     brand,
-                    selectedBrand === brand,
-                    () => onSelectBrand(selectedBrand === brand ? null : brand)
+                    isSameBrand(selectedBrand, brand),
+                    () => onSelectBrand(isSameBrand(selectedBrand, brand) ? null : brand)
                 )
             )}
         </ScrollView>

--- a/styles/ThemeStyles.js
+++ b/styles/ThemeStyles.js
@@ -232,6 +232,30 @@ export const createHomeScreenStyles = (colors) => {
             paddingBottom: space.lg,
             paddingTop: space.xs,
         },
+        filterEmptyState: {
+            alignItems: "center",
+            paddingVertical: space.xl,
+            paddingHorizontal: space.md,
+        },
+        filterEmptyText: {
+            fontSize: 15,
+            fontFamily: fonts.medium,
+            color: colors.secondaryText,
+            marginBottom: space.sm,
+        },
+        filterClearButton: {
+            paddingVertical: space.xs,
+            paddingHorizontal: space.md,
+            borderRadius: radius.pill,
+            backgroundColor: colors.accentSoft,
+            borderWidth: 1,
+            borderColor: colors.accentBorder,
+        },
+        filterClearButtonText: {
+            fontSize: 14,
+            fontFamily: fonts.semibold,
+            color: colors.accent,
+        },
         loadMoreButton: {
             alignSelf: "center",
             paddingVertical: space.sm,

--- a/utils/shopFilters.js
+++ b/utils/shopFilters.js
@@ -46,6 +46,15 @@ const normalizeBrand = (brand) =>
     typeof brand === 'string' ? brand.trim().toLowerCase() : '';
 
 /**
+ * Whether two brand names refer to the same brand (case/whitespace
+ * insensitive). Both must be non-empty to match.
+ */
+export const isSameBrand = (a, b) => {
+    const na = normalizeBrand(a);
+    return na !== '' && na === normalizeBrand(b);
+};
+
+/**
  * Filters shops by brand and/or price.
  * Shops whose upcharge can't be parsed are excluded when a price filter is
  * active — an unverifiable "maybe free" result would defeat the filter.
@@ -74,6 +83,25 @@ export const filterShops = (shops, {brand = null, priceId = null} = {}) => {
         }
         return true;
     });
+};
+
+/**
+ * Ensures the selected brand always has a chip to represent it, even when
+ * a real-time shop update pushes it out of the top-brands list. Without
+ * this, the list/map stay filtered by a brand with no visible, clearable
+ * chip.
+ * @param {Array<string>} brands - Brand names for the chip row
+ * @param {string|null} selectedBrand - Currently active brand filter
+ * @returns {Array<string>} Brands with the selected brand guaranteed present
+ */
+export const ensureBrandIncluded = (brands, selectedBrand) => {
+    const list = Array.isArray(brands) ? brands : [];
+    if (!selectedBrand) return list;
+
+    const wanted = normalizeBrand(selectedBrand);
+    return list.some((brand) => normalizeBrand(brand) === wanted)
+        ? list
+        : [selectedBrand, ...list];
 };
 
 /**

--- a/utils/shopFilters.js
+++ b/utils/shopFilters.js
@@ -1,0 +1,111 @@
+/**
+ * Client-side shop filtering by oat milk brand and upcharge.
+ *
+ * Shops are already fully loaded into HomeScreen state via the Firestore
+ * listener, so filtering (and deriving the brand chips) happens in memory —
+ * no extra queries or schema changes.
+ */
+
+/**
+ * Price filter definitions, keyed by id. `matches` receives the parsed
+ * upcharge amount in dollars (never null).
+ */
+export const PRICE_FILTERS = [
+    {id: 'free', label: '🆓 Free', matches: (amount) => amount === 0},
+    {id: 'under1', label: '💸 Under $1', matches: (amount) => amount < 1},
+];
+
+/**
+ * Parses a shop's upcharge into a dollar amount.
+ * Handles every shape that exists in the data: "Free", "$1.50", "1.50",
+ * ".5", legacy numeric values, and the shop-level isFree flag.
+ * @param {*} upCharge - Raw upCharge value from the shop document
+ * @param {boolean} isFreeFlag - The shop's isFree property, if present
+ * @returns {number|null} Amount in dollars, or null if unparseable/missing
+ */
+export const parseUpchargeAmount = (upCharge, isFreeFlag = false) => {
+    if (isFreeFlag) return 0;
+    if (typeof upCharge === 'number' && Number.isFinite(upCharge) && upCharge >= 0) {
+        return upCharge;
+    }
+    if (typeof upCharge !== 'string') return null;
+
+    const str = upCharge.trim();
+    if (!str) return null;
+    if (str.toLowerCase() === 'free') return 0;
+
+    const match = str.match(/^\$?(\d{1,3}(?:\.\d{0,2})?|\.\d{1,2})$/);
+    return match ? parseFloat(match[1]) : null;
+};
+
+/**
+ * Normalizes a brand name for comparison (matching is case-insensitive
+ * but display keeps the stored casing).
+ */
+const normalizeBrand = (brand) =>
+    typeof brand === 'string' ? brand.trim().toLowerCase() : '';
+
+/**
+ * Filters shops by brand and/or price.
+ * Shops whose upcharge can't be parsed are excluded when a price filter is
+ * active — an unverifiable "maybe free" result would defeat the filter.
+ * @param {Array} shops - Shop objects
+ * @param {Object} filters - {brand: string|null, priceId: string|null}
+ * @returns {Array} Filtered shops (same array if no filters active)
+ */
+export const filterShops = (shops, {brand = null, priceId = null} = {}) => {
+    if (!Array.isArray(shops)) return [];
+    if (!brand && !priceId) return shops;
+
+    const wantedBrand = normalizeBrand(brand);
+    const priceFilter = priceId
+        ? PRICE_FILTERS.find((f) => f.id === priceId)
+        : null;
+
+    return shops.filter((shop) => {
+        if (wantedBrand && normalizeBrand(shop.oatMilk) !== wantedBrand) {
+            return false;
+        }
+        if (priceFilter) {
+            const amount = parseUpchargeAmount(shop.upCharge, shop.isFree);
+            if (amount === null || !priceFilter.matches(amount)) {
+                return false;
+            }
+        }
+        return true;
+    });
+};
+
+/**
+ * Derives the most common oat milk brands from the loaded shops, for use
+ * as filter chips. Groups case-insensitively, displays the most common
+ * casing.
+ * @param {Array} shops - Shop objects
+ * @param {number} limit - Max number of brands to return
+ * @returns {Array<string>} Brand names, most common first
+ */
+export const getTopBrands = (shops, limit = 6) => {
+    if (!Array.isArray(shops)) return [];
+
+    const counts = new Map(); // normalized -> {display: Map<casing, count>, total}
+    for (const shop of shops) {
+        if (typeof shop.oatMilk !== 'string') continue;
+        const display = shop.oatMilk.trim();
+        if (!display) continue;
+        const key = display.toLowerCase();
+
+        if (!counts.has(key)) {
+            counts.set(key, {casings: new Map(), total: 0});
+        }
+        const entry = counts.get(key);
+        entry.total += 1;
+        entry.casings.set(display, (entry.casings.get(display) || 0) + 1);
+    }
+
+    return [...counts.values()]
+        .sort((a, b) => b.total - a.total)
+        .slice(0, limit)
+        .map((entry) =>
+            [...entry.casings.entries()].sort((a, b) => b[1] - a[1])[0][0]
+        );
+};


### PR DESCRIPTION
## Summary

Adds the P0 feature from the triage: filter chips above the shop list so users can narrow the map and list to their oat milk brand and price — the app's core promise ("find shops that serve *your* oat milk, and know if it costs extra").

- **Price chips:** 🆓 Free · 💸 Under $1
- **Brand chips:** top 6 brands, derived in memory from the already-loaded shops — no extra Firestore reads, stays in sync with the real-time listener, and works offline from the cached shop list
- Price and brand filters compose (brand AND price); tapping an active chip clears it
- Map markers, map tap-detection, and the shop list all render the filtered set
- The selected-shop overlay closes automatically if its shop gets filtered out
- Empty state with a one-tap "Clear filters" button when nothing matches

## Design decisions

- **Brand matching is exact (case/whitespace-insensitive)**, so "Oatly" does not match "Oatly Barista" — chips are derived from the same field values, so every chip is guaranteed to match at least one shop.
- **Shops with unparseable upcharge are excluded when a price filter is active.** An unverifiable "maybe free" result would defeat the point of the filter.
- **`parseUpchargeAmount` handles every shape in the data** — `"$1.50"`, `"Free"`, `".5"`, legacy numeric values, and the shop-level `isFree` flag — so this branch does not depend on the validation fixes in #13 (it complements them either way).

## Test plan

- [x] 18 unit assertions on the pure filter logic (parsing all legacy formats, brand exact-match, price composition, top-brand aggregation/casing/ordering, null safety)
- [x] All modified files parse cleanly (babel JSX parse)
- [ ] Visual pass on device: chip styling in light/dark themes, filter + map marker sync, empty state
