### PR TITLE
Add community reports: consensus-based trust for shop data

### DIFF
--- a/COMMUNITY_REPORTS.md
+++ b/COMMUNITY_REPORTS.md
@@ -27,15 +27,24 @@ coffee_shops/{shopId}/reports/{userId}
 
 One report doc per user per shop (doc id = uid): re-reporting overwrites,
 which bounds volume and makes the rate limit enforceable in rules. Repeat
-reports of the same type within 24 h are ignored client-side.
+reports of the same type within 24 h are ignored.
+
+Every submission runs in a **Firestore transaction**: the shop counters and
+the user's previous report are read fresh, so concurrent reports can't lose
+updates, and overwriting your own report reconciles the old contribution
+out of the counters. Counters therefore track **live reports (one per
+user)**, not submission events — a lone user re-disputing can never reach
+the disputed threshold alone.
 
 ## Consensus rules (utils/reportLogic.js, unit-tested)
 
 | Event | Effect |
 |---|---|
-| Confirm | `lastConfirmedAt = now`, `confirmCount + 1` |
+| Confirm | `lastConfirmedAt = now`, `confirmCount + 1` (unchanged if it replaces your own confirmation) |
 | Confirm **on site** | also clears disputes — being at the counter outweighs remote reports |
-| Dispute | `disputeCount + 1`; suggestions stored on the report for admin review |
+| Confirm replacing your own dispute | your dispute is removed from the count |
+| Dispute | `disputeCount + 1` (unchanged if it replaces your own dispute); suggestions stored on the report for admin review |
+| Dispute replacing your own confirmation | your confirmation is removed from the count |
 
 Derived status, shown on cards and the shop detail view:
 
@@ -86,7 +95,9 @@ match /coffee_shops/{shopId} {
 - Consensus is computed client-side and trusted; rules limit blast radius
   but a hostile client can still inflate counters. Server-side aggregation
   (Cloud Function on report write) is the upgrade path.
-- `confirmCount` counts confirmations, not unique confirmers — a user
-  re-confirming after the cooldown increments it again.
+- `lastDisputeOnSite` is a single sticky flag, not per-report: if several
+  users dispute and the on-site one later changes their report, the flag
+  can linger until disputes clear. Exact tracking would require scanning
+  the reports subcollection.
 - Disputed shops are flagged visually but there is no dedicated admin
   "disputed queue" yet; the reports subcollection holds the suggestions.

--- a/COMMUNITY_REPORTS.md
+++ b/COMMUNITY_REPORTS.md
@@ -1,0 +1,92 @@
+# Community Reports: Consensus-Based Trust
+
+Shops no longer just *have* data — they have a stream of community reports
+that continuously confirm or dispute what's displayed. The shop page shows
+*why* the data is trusted ("✓ Confirmed 2w ago · 3 confirmations"), not
+just a checkmark.
+
+## Data model
+
+```
+coffee_shops/{shopId}
+  ├─ oatMilk, upCharge, ...        (displayed values, unchanged)
+  ├─ lastConfirmedAt: Timestamp    ─┐
+  ├─ lastOnSiteConfirmedAt         │ materialized consensus counters,
+  ├─ confirmCount: number          │ updated in the same batch as each
+  ├─ disputeCount: number          │ report so reads stay one doc
+  ├─ lastDisputedAt                │
+  └─ lastDisputeOnSite: boolean    ─┘
+
+coffee_shops/{shopId}/reports/{userId}
+  ├─ type: 'confirm' | 'dispute'
+  ├─ onSite: boolean               (user was within 150 m of the shop)
+  ├─ createdAt, userId
+  ├─ brandAtReport, upChargeAtReport   (what the user saw)
+  └─ suggestedBrand, suggestedUpCharge (disputes only: what it actually is)
+```
+
+One report doc per user per shop (doc id = uid): re-reporting overwrites,
+which bounds volume and makes the rate limit enforceable in rules. Repeat
+reports of the same type within 24 h are ignored client-side.
+
+## Consensus rules (utils/reportLogic.js, unit-tested)
+
+| Event | Effect |
+|---|---|
+| Confirm | `lastConfirmedAt = now`, `confirmCount + 1` |
+| Confirm **on site** | also clears disputes — being at the counter outweighs remote reports |
+| Dispute | `disputeCount + 1`; suggestions stored on the report for admin review |
+
+Derived status, shown on cards and the shop detail view:
+
+- **disputed** — 2+ disputes, or a single on-site dispute
+- **fresh** — confirmed (or created) within the last 90 days
+- **stale** — no confirmation in 90+ days; the UI asks "still accurate?"
+- **unverified** — no usable timestamps at all
+
+Disputes never edit the listing directly — they flag the shop and carry the
+suggested correction; admins fix the listing with the existing Manage flow.
+
+## On-site weighting
+
+The app already knows the user's location. A report made within 150 m of
+the shop (`ONSITE_RADIUS_METERS`) is marked `onSite` and weighted as the
+strongest trust signal — it's cheap Sybil resistance grounded in physics.
+
+## Required Firestore security rules
+
+The client materializes counters itself (there are no Cloud Functions in
+this project), so rules must constrain what a report write can touch:
+
+```
+match /coffee_shops/{shopId} {
+  allow read: if true;
+
+  // Community writes may only touch the consensus counters —
+  // never the shop's displayed data
+  allow update: if request.auth != null
+    && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+      'lastConfirmedAt', 'lastOnSiteConfirmedAt', 'confirmCount',
+      'disputeCount', 'lastDisputedAt', 'lastDisputeOnSite'
+    ]);
+
+  match /reports/{userId} {
+    allow read: if request.auth != null;
+    allow create, update: if request.auth != null
+      && request.auth.uid == userId
+      && request.resource.data.type in ['confirm', 'dispute'];
+  }
+}
+```
+
+(Admin edit/manage rules stay as they are — layer these on top.)
+
+## Known v1 simplifications
+
+- Consensus is computed client-side and trusted; rules limit blast radius
+  but a hostile client can still inflate counters. Server-side aggregation
+  (Cloud Function on report write) is the upgrade path.
+- `confirmCount` counts confirmations, not unique confirmers — a user
+  re-confirming after the cooldown increments it again.
+- Disputed shops are flagged visually but there is no dedicated admin
+  "disputed queue" yet; the reports subcollection holds the suggestions.

--- a/COMMUNITY_REPORTS.md
+++ b/COMMUNITY_REPORTS.md
@@ -50,8 +50,19 @@ Derived status, shown on cards and the shop detail view:
 
 - **disputed** — 2+ disputes, or a single on-site dispute
 - **fresh** — confirmed (or created) within the last 90 days
-- **stale** — no confirmation in 90+ days; the UI asks "still accurate?"
+- **stale** — no confirmation in 90+ days; the detail view invites
+  re-confirmation ("been here recently?")
 - **unverified** — no usable timestamps at all
+
+Display is **positive-only while the community is small**: cards show ✓
+(confirmed) and ⚠ (disputed) badges but never a stale badge — with few
+users almost nothing gets confirmed, and a map full of stale marks reads
+as "abandoned app" rather than honest freshness. Revisit once
+confirmations flow (restore a stale badge in `ShopCard.getFreshnessBadge`).
+
+Admin approval also stamps `lastConfirmedAt`: approval is a human
+verification, so every shop enters the map already carrying a genuine
+freshness signal — no manual founder confirmation pass needed.
 
 Disputes never edit the listing directly — they flag the shop and carry the
 suggested correction; admins fix the listing with the existing Manage flow.

--- a/HomeScreen.js
+++ b/HomeScreen.js
@@ -17,14 +17,17 @@ import AdjustPinModal from "./components/AdjustPinModal";
 import ManageShopModal from "./components/ManageShopModal";
 import ShopCard from "./components/ShopCard";
 import ShopFilterBar from "./components/ShopFilterBar";
+import ReportChangeModal from "./components/ReportChangeModal";
 import {filterShops, getTopBrands} from "./utils/shopFilters";
+import {describeDataStatus} from "./utils/reportLogic";
+import {submitShopReport} from "./services/reportService";
 import {getFormattedUpcharge, getUpchargeColor} from "./utils/upchargeEmojis";
 import {getDirections} from "./utils/MapLinks";
 import {getDistanceMeters} from "./utils/GeoUtils";
 import {useTheme} from "./contexts/ThemeContext";
 import {createHomeScreenStyles} from "./styles/ThemeStyles";
 import {isValidLocation} from "./utils/ValidationUtils";
-import {handleError, handleLocationError} from "./utils/ErrorUtils";
+import {handleError, handleLocationError, showSuccess} from "./utils/ErrorUtils";
 import {loadShopsFromCache, saveShopsToCache, loadFavoritesFromCache, saveFavoritesToCache} from "./services/ShopCache";
 
 export default function HomeScreen() {
@@ -287,6 +290,8 @@ export default function HomeScreen() {
   const [isLoadingFromCache, setIsLoadingFromCache] = useState(true);
   const [brandFilter, setBrandFilter] = useState(null);
   const [priceFilter, setPriceFilter] = useState(null);
+  const [showReportModal, setShowReportModal] = useState(false);
+  const [isSubmittingReport, setIsSubmittingReport] = useState(false);
 
   // Brand chips derived from the loaded shops (no extra Firestore reads,
   // stays in sync with real-time updates, works offline from cache)
@@ -299,10 +304,16 @@ export default function HomeScreen() {
   );
   const hasActiveFilters = brandFilter !== null || priceFilter !== null;
 
-  // If the selected shop gets filtered out, close its overlay
+  // Keep the selected shop in sync with live data: close its overlay if it
+  // gets filtered out, refresh its object when a snapshot update arrives
+  // (so confirmations/disputes reflect immediately in the open card)
   useEffect(() => {
-    if (selectedShop && !visibleShops.some((shop) => shop.id === selectedShop.id)) {
+    if (!selectedShop) return;
+    const updated = visibleShops.find((shop) => shop.id === selectedShop.id);
+    if (!updated) {
       setSelectedShop(null);
+    } else if (updated !== selectedShop) {
+      setSelectedShop(updated);
     }
   }, [visibleShops, selectedShop]);
 
@@ -343,6 +354,73 @@ export default function HomeScreen() {
 
   const handleAdminPanel = () => {
     setShowAdminPanel(true);
+  };
+
+  const handleConfirmShop = async () => {
+    if (!selectedShop || isSubmittingReport) return;
+
+    if (!auth.currentUser) {
+      Alert.alert("Error", "You must be logged in to confirm shop info");
+      return;
+    }
+
+    setIsSubmittingReport(true);
+    try {
+      const result = await submitShopReport({
+        shop: selectedShop,
+        type: "confirm",
+        userId: auth.currentUser.uid,
+        userLocation: location,
+      });
+
+      if (!result.written) {
+        showSuccess("Already counted", "You've confirmed this shop recently — thank you!");
+      } else if (result.onSite) {
+        showSuccess("Thanks!", "Confirmed on site — that's the strongest signal we have. ☕");
+      } else {
+        showSuccess("Thanks!", "Your confirmation was recorded.");
+      }
+    } catch (error) {
+      handleError(error, "Failed to record your confirmation. Please try again.", true, {
+        action: "confirming shop info",
+      });
+    } finally {
+      setIsSubmittingReport(false);
+    }
+  };
+
+  const handleReportChange = async ({ suggestedBrand, suggestedUpCharge }) => {
+    if (!selectedShop || isSubmittingReport) return;
+
+    if (!auth.currentUser) {
+      Alert.alert("Error", "You must be logged in to report a change");
+      return;
+    }
+
+    setIsSubmittingReport(true);
+    try {
+      const result = await submitShopReport({
+        shop: selectedShop,
+        type: "dispute",
+        userId: auth.currentUser.uid,
+        userLocation: location,
+        suggestedBrand,
+        suggestedUpCharge,
+      });
+
+      setShowReportModal(false);
+      if (!result.written) {
+        showSuccess("Already counted", "You've reported this shop recently — thank you!");
+      } else {
+        showSuccess("Thanks!", "Your report was recorded and this shop will be reviewed.");
+      }
+    } catch (error) {
+      handleError(error, "Failed to send your report. Please try again.", true, {
+        action: "reporting shop change",
+      });
+    } finally {
+      setIsSubmittingReport(false);
+    }
   };
 
   const handleShare = async () => {
@@ -1277,6 +1355,62 @@ export default function HomeScreen() {
                 )}
               </View>
 
+              {/* Community trust row: freshness status + confirm/dispute */}
+              {(() => {
+                const {status, label} = describeDataStatus(selectedShop);
+                const statusColor =
+                  status === "fresh"
+                    ? colors.success
+                    : status === "disputed"
+                      ? colors.danger
+                      : status === "stale"
+                        ? colors.warning
+                        : colors.tertiaryText;
+                return (
+                  <View style={styles.communityRow}>
+                    <Text style={[styles.communityStatusText, { color: statusColor }]}>
+                      {label}
+                    </Text>
+                    <View style={styles.communityActions}>
+                      <TouchableOpacity
+                        style={[
+                          styles.communityButton,
+                          isSubmittingReport && styles.communityButtonDisabled,
+                        ]}
+                        onPress={handleConfirmShop}
+                        disabled={isSubmittingReport}
+                        activeOpacity={0.7}
+                      >
+                        <FontAwesome6
+                          name="check"
+                          size={12}
+                          color={colors.success}
+                          iconStyle="solid"
+                        />
+                        <Text style={styles.communityButtonText}>Still accurate</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[
+                          styles.communityButton,
+                          isSubmittingReport && styles.communityButtonDisabled,
+                        ]}
+                        onPress={() => setShowReportModal(true)}
+                        disabled={isSubmittingReport}
+                        activeOpacity={0.7}
+                      >
+                        <FontAwesome6
+                          name="pen"
+                          size={12}
+                          color={colors.warning}
+                          iconStyle="solid"
+                        />
+                        <Text style={styles.communityButtonText}>Report a change</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                );
+              })()}
+
               {/* Action Buttons */}
               <View style={styles.actionButtons}>
                 <TouchableOpacity
@@ -1375,6 +1509,14 @@ export default function HomeScreen() {
           </Animated.View>
         </Animated.View>
       )}
+
+      <ReportChangeModal
+        visible={showReportModal}
+        shop={selectedShop}
+        onClose={() => setShowReportModal(false)}
+        onSubmit={handleReportChange}
+        isSubmitting={isSubmittingReport}
+      />
 
       <Modal
         animationType="slide"

--- a/HomeScreen.js
+++ b/HomeScreen.js
@@ -1363,9 +1363,9 @@ export default function HomeScreen() {
                     ? colors.success
                     : status === "disputed"
                       ? colors.danger
-                      : status === "stale"
-                        ? colors.warning
-                        : colors.tertiaryText;
+                      // Stale/unverified read as neutral invitations, not
+                      // warnings — expected state while the community is small
+                      : colors.tertiaryText;
                 return (
                   <View style={styles.communityRow}>
                     <Text style={[styles.communityStatusText, { color: statusColor }]}>

--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -77,9 +77,10 @@ service cloud.firestore {
 
 ## 4. Optional decisions
 
-- [ ] Old shops will show the ⏳ stale badge immediately (nothing has ever
-      confirmed them). If that's too aggressive for launch, widen
-      `FRESHNESS_WINDOW_DAYS` in `utils/reportLogic.js` (currently 90).
+- [ ] Badges are positive-only (✓ / ⚠, never a stale badge) since the
+      community is small. When confirmations actually flow, consider
+      restoring a stale badge in `ShopCard.getFreshnessBadge` and/or
+      tuning `FRESHNESS_WINDOW_DAYS` in `utils/reportLogic.js` (90).
 - [ ] No data migration or backfill is needed — counter fields appear
       lazily as reports come in. Nothing to run.
 - [ ] When submissions grow: consider a Cloud Function to compute the

--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -1,0 +1,87 @@
+# Manual Steps Before Shipping
+
+Owner to-do list for the three open PRs. Everything code-side is done;
+these are the steps only you can do.
+
+## 1. Merge order
+
+- [ ] Merge **#13** (fuzz fixes) — independent, merge any time
+- [ ] Merge **#14** (filter chips) — independent, merge any time
+- [ ] Merge **#15** (community reports) — stacked on #14's branch.
+      Merge #14 first; GitHub retargets #15 to `main` automatically.
+      **Do not merge #15 before completing step 2.**
+
+## 2. Firestore security rules (required for #15)
+
+Without this, confirm/dispute either fails with permission-denied (if your
+rules are restrictive) or — worse — leaves shop listings editable by any
+authenticated client (if they're permissive).
+
+Firebase Console → **Firestore Database** → **Rules** tab → edit → **Publish**.
+
+Merge the following into your existing rules (keep your current admin,
+`pendingShops`, and `users` rules as they are — this only adds the
+community-report paths):
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /coffee_shops/{shopId} {
+      allow read: if true;
+
+      // Community consensus writes: authenticated users may update ONLY
+      // the counter fields — never the shop's displayed data.
+      // (Keep your existing admin update/delete rules alongside this.)
+      allow update: if request.auth != null
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+          'lastConfirmedAt', 'lastOnSiteConfirmedAt', 'confirmCount',
+          'disputeCount', 'lastDisputedAt', 'lastDisputeOnSite'
+        ]);
+
+      // One report doc per user, keyed by their uid
+      match /reports/{userId} {
+        allow read: if request.auth != null;
+        allow create, update: if request.auth != null
+          && request.auth.uid == userId
+          && request.resource.data.type in ['confirm', 'dispute']
+          && request.resource.data.userId == userId;
+      }
+    }
+
+    // ... your existing rules for pendingShops, users, etc. ...
+  }
+}
+```
+
+- [ ] Rules merged and published
+- [ ] Sanity check in the console **Rules Playground**:
+      - authenticated update to `coffee_shops/{id}` touching only
+        `confirmCount` + `lastConfirmedAt` → **allowed**
+      - authenticated update touching `oatMilk` or `upCharge` → **denied**
+        (unless it matches your admin rule)
+      - write to `coffee_shops/{id}/reports/<other-user's-uid>` → **denied**
+
+## 3. On-device verification (nothing in these PRs was device-tested)
+
+- [ ] **#14 filters:** chips render in light + dark theme; brand + price
+      filters compose; map markers shrink with the list; "Clear filters"
+      empty state works
+- [ ] **#15 reports:** tap "Still accurate" → success alert, shop shows
+      "✓ Confirmed today"; repeat within 24 h → "Already counted";
+      "Report a change" → modal validates and submits; check Firestore
+      console for the report doc under `coffee_shops/{id}/reports/{uid}`
+- [ ] Confirm while physically at a café (or spoof location) → alert says
+      "Confirmed on site"
+
+## 4. Optional decisions
+
+- [ ] Old shops will show the ⏳ stale badge immediately (nothing has ever
+      confirmed them). If that's too aggressive for launch, widen
+      `FRESHNESS_WINDOW_DAYS` in `utils/reportLogic.js` (currently 90).
+- [ ] No data migration or backfill is needed — counter fields appear
+      lazily as reports come in. Nothing to run.
+- [ ] When submissions grow: consider a Cloud Function to compute the
+      consensus counters server-side (upgrade path noted in
+      `COMMUNITY_REPORTS.md`).

--- a/components/AdminScreen.js
+++ b/components/AdminScreen.js
@@ -154,6 +154,9 @@ const AdminScreen = ({onClose}) => {
                                     createdAt: shop.createdAt || new Date(),
                                     approvedAt: new Date(),
                                     approvedBy: auth.currentUser.uid,
+                                    // Approval is a human verification, so the shop
+                                    // enters the map with a genuine freshness stamp
+                                    lastConfirmedAt: new Date(),
                                 };
                                 transaction.set(newShopRef, shopData);
 

--- a/components/ReportChangeModal.js
+++ b/components/ReportChangeModal.js
@@ -1,0 +1,256 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {
+    KeyboardAvoidingView,
+    Modal,
+    Platform,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import {useTheme} from '../contexts/ThemeContext';
+import {fonts, radius, space} from '../styles/tokens';
+import {validateOatMilk, validateUpcharge} from '../utils/ValidationUtils';
+
+/**
+ * Small modal for disputing a shop's displayed info: the user says what
+ * the brand/upcharge actually is now. Suggestions are stored on the
+ * report for admins to act on; they do not directly edit the shop.
+ */
+const ReportChangeModal = ({visible, shop, onClose, onSubmit, isSubmitting = false}) => {
+    const {colors} = useTheme();
+    const styles = useMemo(() => getStyles(colors), [colors]);
+
+    const [brand, setBrand] = useState('');
+    const [upCharge, setUpCharge] = useState('');
+    const [isFree, setIsFree] = useState(false);
+    const [error, setError] = useState('');
+
+    // Re-seed the form from the shop each time the modal opens
+    useEffect(() => {
+        if (visible && shop) {
+            setBrand(typeof shop.oatMilk === 'string' ? shop.oatMilk : '');
+            const current = typeof shop.upCharge === 'string' ? shop.upCharge : '';
+            setIsFree(current.toLowerCase() === 'free');
+            setUpCharge(current.toLowerCase() === 'free' ? '' : current.replace(/[^0-9.]/g, ''));
+            setError('');
+        }
+    }, [visible, shop]);
+
+    const handleSubmit = () => {
+        const brandValidation = validateOatMilk(brand);
+        if (!brandValidation.isValid) {
+            setError(brandValidation.message);
+            return;
+        }
+
+        const upchargeValidation = validateUpcharge(upCharge, isFree);
+        if (!upchargeValidation.isValid) {
+            setError(upchargeValidation.message);
+            return;
+        }
+
+        setError('');
+        onSubmit({
+            suggestedBrand: brandValidation.sanitized,
+            suggestedUpCharge: upchargeValidation.sanitized,
+        });
+    };
+
+    if (!shop) return null;
+
+    return (
+        <Modal
+            animationType="fade"
+            transparent
+            visible={visible}
+            onRequestClose={onClose}
+        >
+            <KeyboardAvoidingView
+                style={styles.backdrop}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            >
+                <View style={styles.card}>
+                    <Text style={styles.title}>What changed at {shop.name}?</Text>
+                    <Text style={styles.subtitle}>
+                        Your report flags this shop for review — it won't change the
+                        listing directly.
+                    </Text>
+
+                    <Text style={styles.fieldLabel}>Oat milk brand</Text>
+                    <TextInput
+                        style={styles.input}
+                        value={brand}
+                        onChangeText={setBrand}
+                        placeholder="e.g. Oatly"
+                        placeholderTextColor={colors.tertiaryText}
+                        maxLength={30}
+                    />
+
+                    <Text style={styles.fieldLabel}>Upcharge</Text>
+                    <View style={styles.upchargeRow}>
+                        <TextInput
+                            style={[styles.input, styles.upchargeInput, isFree && styles.inputDisabled]}
+                            value={upCharge}
+                            onChangeText={(value) => setUpCharge(value.replace(/[^0-9.]/g, ''))}
+                            placeholder="0.50"
+                            placeholderTextColor={colors.tertiaryText}
+                            keyboardType="decimal-pad"
+                            editable={!isFree}
+                            maxLength={6}
+                        />
+                        <TouchableOpacity
+                            style={[styles.freeChip, isFree && styles.freeChipSelected]}
+                            onPress={() => setIsFree(!isFree)}
+                            activeOpacity={0.7}
+                        >
+                            <Text style={[styles.freeChipText, isFree && styles.freeChipTextSelected]}>
+                                🆓 Free
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+
+                    {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+                    <View style={styles.actions}>
+                        <TouchableOpacity
+                            style={styles.cancelButton}
+                            onPress={onClose}
+                            activeOpacity={0.7}
+                            disabled={isSubmitting}
+                        >
+                            <Text style={styles.cancelButtonText}>Cancel</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            style={[styles.submitButton, isSubmitting && styles.submitButtonDisabled]}
+                            onPress={handleSubmit}
+                            activeOpacity={0.8}
+                            disabled={isSubmitting}
+                        >
+                            <Text style={styles.submitButtonText}>
+                                {isSubmitting ? 'Sending…' : 'Send report'}
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </KeyboardAvoidingView>
+        </Modal>
+    );
+};
+
+const getStyles = (colors) => StyleSheet.create({
+    backdrop: {
+        flex: 1,
+        backgroundColor: colors.modalBackground,
+        justifyContent: 'center',
+        padding: space.lg,
+    },
+    card: {
+        backgroundColor: colors.surface,
+        borderRadius: radius.xl,
+        borderWidth: 1,
+        borderColor: colors.border,
+        padding: space.lg,
+    },
+    title: {
+        fontSize: 18,
+        fontFamily: fonts.displaySemi,
+        color: colors.text,
+        marginBottom: space.xxs,
+    },
+    subtitle: {
+        fontSize: 13,
+        fontFamily: fonts.body,
+        color: colors.secondaryText,
+        marginBottom: space.md,
+    },
+    fieldLabel: {
+        fontSize: 13,
+        fontFamily: fonts.semibold,
+        color: colors.secondaryText,
+        marginBottom: space.xxs,
+    },
+    input: {
+        backgroundColor: colors.inputBackground,
+        borderRadius: radius.sm,
+        borderWidth: 1,
+        borderColor: colors.border,
+        paddingHorizontal: space.sm,
+        paddingVertical: space.xs,
+        fontSize: 15,
+        fontFamily: fonts.medium,
+        color: colors.text,
+        marginBottom: space.sm,
+    },
+    inputDisabled: {
+        opacity: 0.4,
+    },
+    upchargeRow: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: space.xs,
+    },
+    upchargeInput: {
+        flex: 1,
+    },
+    freeChip: {
+        paddingHorizontal: space.sm,
+        paddingVertical: space.xs,
+        borderRadius: radius.pill,
+        backgroundColor: colors.surfaceMuted,
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+    freeChipSelected: {
+        backgroundColor: colors.successSoft,
+        borderColor: colors.success,
+    },
+    freeChipText: {
+        fontSize: 13,
+        fontFamily: fonts.medium,
+        color: colors.secondaryText,
+    },
+    freeChipTextSelected: {
+        color: colors.success,
+        fontFamily: fonts.semibold,
+    },
+    errorText: {
+        fontSize: 13,
+        fontFamily: fonts.medium,
+        color: colors.danger,
+        marginBottom: space.xs,
+    },
+    actions: {
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        gap: space.sm,
+        marginTop: space.xs,
+    },
+    cancelButton: {
+        paddingVertical: space.xs,
+        paddingHorizontal: space.md,
+        borderRadius: radius.pill,
+    },
+    cancelButtonText: {
+        fontSize: 14,
+        fontFamily: fonts.semibold,
+        color: colors.secondaryText,
+    },
+    submitButton: {
+        paddingVertical: space.xs,
+        paddingHorizontal: space.md,
+        borderRadius: radius.pill,
+        backgroundColor: colors.accent,
+    },
+    submitButtonDisabled: {
+        opacity: 0.6,
+    },
+    submitButtonText: {
+        fontSize: 14,
+        fontFamily: fonts.semibold,
+        color: colors.onAccent,
+    },
+});
+
+export default ReportChangeModal;

--- a/components/ShopCard.js
+++ b/components/ShopCard.js
@@ -8,6 +8,12 @@ import { useTheme } from '../contexts/ThemeContext';
 
 /**
  * Compact freshness badge content for a shop card.
+ *
+ * Positive-only: cards show ✓ when confirmed and ⚠ when disputed, and
+ * nothing otherwise. With a small user base almost nothing gets confirmed,
+ * so a stale badge would wallpaper the map with "abandoned" signals the
+ * data can't earn its way out of. The detail view still nudges for
+ * re-confirmation of stale shops.
  * @returns {{text: string, colorKey: string}|null} null when there's nothing useful to show
  */
 const getFreshnessBadge = (shop) => {
@@ -17,10 +23,6 @@ const getFreshnessBadge = (shop) => {
   }
   if (status === 'fresh' && shop.lastConfirmedAt) {
     return { text: `✓ ${formatTimeAgo(shop.lastConfirmedAt)}`, colorKey: 'success' };
-  }
-  if (status === 'stale') {
-    const ago = formatTimeAgo(shop.lastConfirmedAt || shop.createdAt);
-    return ago ? { text: `⏳ ${ago}`, colorKey: 'tertiaryText' } : null;
   }
   return null;
 };

--- a/components/ShopCard.js
+++ b/components/ShopCard.js
@@ -3,7 +3,27 @@ import { View, Text, TouchableOpacity, Animated, Image } from 'react-native';
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6';
 import { getFormattedUpcharge, getUpchargeColor } from '../utils/upchargeEmojis';
 import { getDistanceMeters } from '../utils/GeoUtils';
+import { deriveDataStatus, formatTimeAgo } from '../utils/reportLogic';
 import { useTheme } from '../contexts/ThemeContext';
+
+/**
+ * Compact freshness badge content for a shop card.
+ * @returns {{text: string, colorKey: string}|null} null when there's nothing useful to show
+ */
+const getFreshnessBadge = (shop) => {
+  const status = deriveDataStatus(shop);
+  if (status === 'disputed') {
+    return { text: '⚠ disputed', colorKey: 'danger' };
+  }
+  if (status === 'fresh' && shop.lastConfirmedAt) {
+    return { text: `✓ ${formatTimeAgo(shop.lastConfirmedAt)}`, colorKey: 'success' };
+  }
+  if (status === 'stale') {
+    const ago = formatTimeAgo(shop.lastConfirmedAt || shop.createdAt);
+    return ago ? { text: `⏳ ${ago}`, colorKey: 'tertiaryText' } : null;
+  }
+  return null;
+};
 
 const ShopCard = ({
   item,
@@ -15,6 +35,8 @@ const ShopCard = ({
   const { colors } = useTheme();
   // Create animated value with useRef to prevent recreation on each render
   const scaleAnim = useRef(new Animated.Value(1)).current;
+
+  const freshness = getFreshnessBadge(item);
 
   const handlePressIn = () => {
     Animated.spring(scaleAnim, {
@@ -92,6 +114,11 @@ const ShopCard = ({
                       ).toFixed(1)}km away`
                     : "Location unavailable"}
                 </Text>
+                {freshness && (
+                  <Text style={[styles.freshnessBadge, { color: colors[freshness.colorKey] }]}>
+                    {freshness.text}
+                  </Text>
+                )}
                 {isFavorite && (
                   <FontAwesome6
                     name="heart"

--- a/services/reportService.js
+++ b/services/reportService.js
@@ -6,12 +6,17 @@
  * user per shop (re-reporting overwrites), which naturally bounds report
  * volume and makes the per-user rate limit enforceable in security rules.
  * The consensus counters the report implies are materialized onto the shop
- * document in the same batch so reads stay a single doc.
+ * document in the same write.
+ *
+ * The whole submission runs in a Firestore transaction: the shop's counters
+ * and the user's previous report are read fresh, so concurrent reports
+ * can't lose updates, and overwriting one's own report reconciles the old
+ * contribution out of the counters instead of double-counting it.
  *
  * Consensus rules live in utils/reportLogic.js (pure, unit-tested).
  */
 
-import {doc, getDoc, writeBatch} from 'firebase/firestore';
+import {doc, runTransaction} from 'firebase/firestore';
 import {db} from './firebase';
 import {computeShopUpdateForReport, isOnSite, toMillis} from '../utils/reportLogic';
 
@@ -52,47 +57,65 @@ export const submitShopReport = async ({
 
     const now = Date.now();
     const onSite = isOnSite(userLocation, shop.location);
+    const shopRef = doc(db, 'coffee_shops', shop.id);
     const reportRef = doc(db, 'coffee_shops', shop.id, 'reports', userId);
 
-    // Ignore repeat reports of the same type within the cooldown window
-    const existing = await getDoc(reportRef);
-    if (existing.exists()) {
-        const previous = existing.data();
-        const previousAt = toMillis(previous.createdAt);
-        if (
-            previous.type === type &&
-            previousAt != null &&
-            now - previousAt < REPORT_COOLDOWN_MS
-        ) {
-            return {written: false, onSite, reason: 'cooldown'};
+    return runTransaction(db, async (transaction) => {
+        const shopSnap = await transaction.get(shopRef);
+        if (!shopSnap.exists()) {
+            throw new Error('This shop no longer exists');
         }
-    }
+        const shopData = shopSnap.data();
 
-    const report = {
-        type,
-        onSite,
-        userId,
-        createdAt: new Date(now),
-        // Snapshot what the user saw, so disputes stay meaningful after edits
-        brandAtReport: shop.oatMilk ?? null,
-        upChargeAtReport: shop.upCharge ?? null,
-    };
-    if (type === 'dispute') {
-        report.suggestedBrand = suggestedBrand;
-        report.suggestedUpCharge = suggestedUpCharge;
-    }
+        // Reconcile against the user's previous report, if any
+        const reportSnap = await transaction.get(reportRef);
+        let previousType = null;
+        if (reportSnap.exists()) {
+            const previous = reportSnap.data();
+            const previousAt = toMillis(previous.createdAt);
 
-    const shopUpdate = computeShopUpdateForReport(shop, {type, onSite, now});
-    for (const field of TIMESTAMP_FIELDS) {
-        if (field in shopUpdate) {
-            shopUpdate[field] = new Date(shopUpdate[field]);
+            // Ignore repeat reports of the same type within the cooldown
+            if (
+                previous.type === type &&
+                previousAt != null &&
+                now - previousAt < REPORT_COOLDOWN_MS
+            ) {
+                return {written: false, onSite, reason: 'cooldown'};
+            }
+            if (previous.type === 'confirm' || previous.type === 'dispute') {
+                previousType = previous.type;
+            }
         }
-    }
 
-    const batch = writeBatch(db);
-    batch.set(reportRef, report);
-    batch.update(doc(db, 'coffee_shops', shop.id), shopUpdate);
-    await batch.commit();
+        const report = {
+            type,
+            onSite,
+            userId,
+            createdAt: new Date(now),
+            // Snapshot what the user saw, so disputes stay meaningful after edits
+            brandAtReport: shopData.oatMilk ?? null,
+            upChargeAtReport: shopData.upCharge ?? null,
+        };
+        if (type === 'dispute') {
+            report.suggestedBrand = suggestedBrand;
+            report.suggestedUpCharge = suggestedUpCharge;
+        }
 
-    return {written: true, onSite};
+        const shopUpdate = computeShopUpdateForReport(shopData, {
+            type,
+            onSite,
+            now,
+            previousType,
+        });
+        for (const field of TIMESTAMP_FIELDS) {
+            if (field in shopUpdate) {
+                shopUpdate[field] = new Date(shopUpdate[field]);
+            }
+        }
+
+        transaction.set(reportRef, report);
+        transaction.update(shopRef, shopUpdate);
+
+        return {written: true, onSite};
+    });
 };

--- a/services/reportService.js
+++ b/services/reportService.js
@@ -1,0 +1,98 @@
+/**
+ * Community report writes: one-tap confirmations and "this changed"
+ * disputes against a shop's displayed data.
+ *
+ * Data model: coffee_shops/{shopId}/reports/{userId} — one live report per
+ * user per shop (re-reporting overwrites), which naturally bounds report
+ * volume and makes the per-user rate limit enforceable in security rules.
+ * The consensus counters the report implies are materialized onto the shop
+ * document in the same batch so reads stay a single doc.
+ *
+ * Consensus rules live in utils/reportLogic.js (pure, unit-tested).
+ */
+
+import {doc, getDoc, writeBatch} from 'firebase/firestore';
+import {db} from './firebase';
+import {computeShopUpdateForReport, isOnSite, toMillis} from '../utils/reportLogic';
+
+// A user's repeat report of the same type within this window is ignored
+const REPORT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+const TIMESTAMP_FIELDS = ['lastConfirmedAt', 'lastDisputedAt', 'lastOnSiteConfirmedAt'];
+
+/**
+ * Records a community report for a shop and updates its consensus counters.
+ *
+ * @param {Object} params
+ * @param {Object} params.shop - Shop object (needs id, location, oatMilk, upCharge)
+ * @param {'confirm'|'dispute'} params.type - Report type
+ * @param {string} params.userId - Authenticated user's uid
+ * @param {Object|null} params.userLocation - Current user location, for on-site weighting
+ * @param {string|null} params.suggestedBrand - For disputes: what the brand actually is
+ * @param {string|null} params.suggestedUpCharge - For disputes: what the upcharge actually is
+ * @returns {Promise<{written: boolean, onSite: boolean, reason?: string}>}
+ */
+export const submitShopReport = async ({
+    shop,
+    type,
+    userId,
+    userLocation = null,
+    suggestedBrand = null,
+    suggestedUpCharge = null,
+}) => {
+    if (!shop || !shop.id) {
+        throw new Error('A shop with an id is required');
+    }
+    if (!userId) {
+        throw new Error('You must be logged in to report');
+    }
+    if (type !== 'confirm' && type !== 'dispute') {
+        throw new Error(`Unknown report type: ${type}`);
+    }
+
+    const now = Date.now();
+    const onSite = isOnSite(userLocation, shop.location);
+    const reportRef = doc(db, 'coffee_shops', shop.id, 'reports', userId);
+
+    // Ignore repeat reports of the same type within the cooldown window
+    const existing = await getDoc(reportRef);
+    if (existing.exists()) {
+        const previous = existing.data();
+        const previousAt = toMillis(previous.createdAt);
+        if (
+            previous.type === type &&
+            previousAt != null &&
+            now - previousAt < REPORT_COOLDOWN_MS
+        ) {
+            return {written: false, onSite, reason: 'cooldown'};
+        }
+    }
+
+    const report = {
+        type,
+        onSite,
+        userId,
+        createdAt: new Date(now),
+        // Snapshot what the user saw, so disputes stay meaningful after edits
+        brandAtReport: shop.oatMilk ?? null,
+        upChargeAtReport: shop.upCharge ?? null,
+    };
+    if (type === 'dispute') {
+        report.suggestedBrand = suggestedBrand;
+        report.suggestedUpCharge = suggestedUpCharge;
+    }
+
+    const shopUpdate = computeShopUpdateForReport(shop, {type, onSite, now});
+    for (const field of TIMESTAMP_FIELDS) {
+        if (field in shopUpdate) {
+            shopUpdate[field] = new Date(shopUpdate[field]);
+        }
+    }
+
+    const batch = writeBatch(db);
+    batch.set(reportRef, report);
+    batch.update(doc(db, 'coffee_shops', shop.id), shopUpdate);
+    await batch.commit();
+
+    return {written: true, onSite};
+};

--- a/styles/ThemeStyles.js
+++ b/styles/ThemeStyles.js
@@ -256,6 +256,41 @@ export const createHomeScreenStyles = (colors) => {
             fontFamily: fonts.semibold,
             color: colors.accent,
         },
+        freshnessBadge: {
+            fontSize: 12,
+            fontFamily: fonts.semibold,
+        },
+        communityRow: {
+            marginBottom: space.md,
+        },
+        communityStatusText: {
+            fontSize: 13,
+            fontFamily: fonts.semibold,
+            marginBottom: space.xs,
+        },
+        communityActions: {
+            flexDirection: "row",
+            gap: space.xs,
+        },
+        communityButton: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: space.xxs + 2,
+            paddingVertical: space.xs,
+            paddingHorizontal: space.sm,
+            borderRadius: radius.pill,
+            backgroundColor: colors.surfaceMuted,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        communityButtonDisabled: {
+            opacity: 0.5,
+        },
+        communityButtonText: {
+            fontSize: 13,
+            fontFamily: fonts.semibold,
+            color: colors.text,
+        },
         loadMoreButton: {
             alignSelf: "center",
             paddingVertical: space.sm,

--- a/utils/reportLogic.js
+++ b/utils/reportLogic.js
@@ -117,33 +117,59 @@ export const describeDataStatus = (shop, now = Date.now()) => {
  * Computes the materialized counter updates a report applies to its shop
  * document. Timestamps are returned as epoch millis; the service layer
  * converts them to Dates for Firestore.
+ *
+ * Because a user's report doc is keyed by uid, submitting again OVERWRITES
+ * their previous report — so `previousType` is used to reconcile the old
+ * contribution out of the counters first. Counters therefore track live
+ * reports (one per user), not submission events: a lone user re-disputing
+ * can never push disputeCount to the disputed threshold by themselves.
+ *
+ * Must be called with fresh shop data (the service runs it inside a
+ * Firestore transaction) so concurrent reports can't clobber each other.
+ *
  * @param {Object} shop - Current shop document data
- * @param {Object} report - {type: 'confirm'|'dispute', onSite: boolean, now?: number}
+ * @param {Object} report - {type, onSite, now?, previousType?} where
+ *   previousType is the user's overwritten report type, if any
  * @returns {Object} Field updates for the shop document
  */
-export const computeShopUpdateForReport = (shop, {type, onSite = false, now = Date.now()}) => {
+export const computeShopUpdateForReport = (
+    shop,
+    {type, onSite = false, now = Date.now(), previousType = null}
+) => {
     const confirmCount = (shop && shop.confirmCount) || 0;
     const disputeCount = (shop && shop.disputeCount) || 0;
+    const hadOnSiteDispute = Boolean(shop && shop.lastDisputeOnSite);
 
     if (type === 'confirm') {
-        const update = {
+        // Replacing our own dispute removes it; an on-site confirmation
+        // clears all disputes — being at the counter outweighs remote reports
+        let newDisputeCount = previousType === 'dispute'
+            ? Math.max(0, disputeCount - 1)
+            : disputeCount;
+        if (onSite) newDisputeCount = 0;
+
+        return {
             lastConfirmedAt: now,
-            confirmCount: confirmCount + 1,
+            // Replacing our own confirmation refreshes the clock without
+            // inflating the count
+            confirmCount: confirmCount + (previousType === 'confirm' ? 0 : 1),
+            disputeCount: newDisputeCount,
+            lastDisputeOnSite: newDisputeCount === 0 ? false : hadOnSiteDispute,
+            ...(onSite ? {lastOnSiteConfirmedAt: now} : {}),
         };
-        if (onSite) {
-            // Being at the counter outweighs remote disputes
-            update.lastOnSiteConfirmedAt = now;
-            update.disputeCount = 0;
-            update.lastDisputeOnSite = false;
-        }
-        return update;
     }
 
     if (type === 'dispute') {
+        const newDisputeCount = disputeCount + (previousType === 'dispute' ? 0 : 1);
         return {
-            disputeCount: disputeCount + 1,
+            disputeCount: newDisputeCount,
             lastDisputedAt: now,
-            lastDisputeOnSite: Boolean(onSite || (shop && shop.lastDisputeOnSite)),
+            // The sticky on-site flag only survives if disputes other than
+            // this user's replaced one could have set it
+            lastDisputeOnSite: onSite || (newDisputeCount > 1 && hadOnSiteDispute),
+            ...(previousType === 'confirm'
+                ? {confirmCount: Math.max(0, confirmCount - 1)}
+                : {}),
         };
     }
 

--- a/utils/reportLogic.js
+++ b/utils/reportLogic.js
@@ -105,12 +105,14 @@ export const describeDataStatus = (shop, now = Date.now()) => {
             : {status, label: `Added ${ago} — not yet confirmed`};
     }
     if (status === 'stale') {
+        // Phrased as an invitation to re-confirm, not a warning — staleness
+        // is expected while the community is small
         const ago = formatTimeAgo(toMillis(shop.lastConfirmedAt) ?? toMillis(shop.createdAt), now);
         return shop.lastConfirmedAt
-            ? {status, label: `⏳ Last confirmed ${ago} — still accurate?`}
-            : {status, label: `⏳ Added ${ago} — never confirmed`};
+            ? {status, label: `Last confirmed ${ago} — been here recently?`}
+            : {status, label: `Added ${ago} — been here recently?`};
     }
-    return {status, label: 'Not yet confirmed by the community'};
+    return {status, label: 'Been here? Help confirm this info'};
 };
 
 /**

--- a/utils/reportLogic.js
+++ b/utils/reportLogic.js
@@ -1,0 +1,151 @@
+/**
+ * Pure consensus rules for community shop reports.
+ *
+ * A shop's displayed data (brand, upcharge) is treated as a claim that the
+ * community continuously confirms or disputes. The rules are deliberately
+ * simple and explainable:
+ *
+ * - A confirmation refreshes the shop's freshness clock.
+ * - An ON-SITE confirmation (made within ONSITE_RADIUS_METERS of the shop)
+ *   is the strongest signal: it also clears standing disputes.
+ * - A shop becomes "disputed" after DISPUTE_THRESHOLD disputes, or a single
+ *   on-site dispute.
+ * - Data older than FRESHNESS_WINDOW_DAYS without confirmation is "stale".
+ *
+ * Everything here is pure (no Firestore imports) so it can be unit-tested;
+ * services/reportService.js applies these rules to the database.
+ */
+
+import {getDistanceMeters} from './GeoUtils';
+
+export const ONSITE_RADIUS_METERS = 150;
+export const FRESHNESS_WINDOW_DAYS = 90;
+export const DISPUTE_THRESHOLD = 2;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Converts the timestamp shapes that appear in this codebase to epoch
+ * millis: Firestore Timestamp, Date, number, ISO string.
+ * @returns {number|null} Epoch millis, or null if unusable
+ */
+export const toMillis = (value) => {
+    if (value == null) return null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    if (value instanceof Date) return value.getTime();
+    if (typeof value.toMillis === 'function') return value.toMillis();
+    if (typeof value.seconds === 'number') return value.seconds * 1000;
+    if (typeof value === 'string') {
+        const t = Date.parse(value);
+        return Number.isNaN(t) ? null : t;
+    }
+    return null;
+};
+
+/**
+ * Whether the user is physically at the shop (within ONSITE_RADIUS_METERS).
+ */
+export const isOnSite = (userLocation, shopLocation) => {
+    if (!userLocation || !shopLocation) return false;
+    const distance = getDistanceMeters(userLocation, shopLocation);
+    return Number.isFinite(distance) && distance <= ONSITE_RADIUS_METERS;
+};
+
+/**
+ * Derives a shop's trust status from its materialized report counters.
+ * @returns {'disputed'|'fresh'|'stale'|'unverified'}
+ */
+export const deriveDataStatus = (shop, now = Date.now()) => {
+    if (!shop) return 'unverified';
+
+    const disputes = shop.disputeCount || 0;
+    if (disputes >= DISPUTE_THRESHOLD || (disputes >= 1 && shop.lastDisputeOnSite)) {
+        return 'disputed';
+    }
+
+    const reference = toMillis(shop.lastConfirmedAt) ?? toMillis(shop.createdAt);
+    if (reference == null) return 'unverified';
+
+    return now - reference <= FRESHNESS_WINDOW_DAYS * DAY_MS ? 'fresh' : 'stale';
+};
+
+/**
+ * Compact "how long ago" formatting for freshness display.
+ * @returns {string|null} e.g. 'today', '3d ago', '2w ago', '4mo ago'
+ */
+export const formatTimeAgo = (value, now = Date.now()) => {
+    const t = toMillis(value);
+    if (t == null) return null;
+
+    const days = Math.floor(Math.max(0, now - t) / DAY_MS);
+    if (days < 1) return 'today';
+    if (days < 14) return `${days}d ago`;
+    if (days < 60) return `${Math.floor(days / 7)}w ago`;
+    if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+    return `${Math.floor(days / 365)}y ago`;
+};
+
+/**
+ * Human-readable status line for the shop detail view, so the app can show
+ * WHY data is trusted rather than just a checkmark.
+ * @returns {{status: string, label: string}}
+ */
+export const describeDataStatus = (shop, now = Date.now()) => {
+    const status = deriveDataStatus(shop, now);
+
+    if (status === 'disputed') {
+        return {status, label: '⚠ Recent reports say this info may have changed'};
+    }
+    if (status === 'fresh') {
+        const ago = formatTimeAgo(toMillis(shop.lastConfirmedAt) ?? toMillis(shop.createdAt), now);
+        const count = shop.confirmCount || 0;
+        const suffix = count > 1 ? ` · ${count} confirmations` : '';
+        return shop.lastConfirmedAt
+            ? {status, label: `✓ Confirmed ${ago}${suffix}`}
+            : {status, label: `Added ${ago} — not yet confirmed`};
+    }
+    if (status === 'stale') {
+        const ago = formatTimeAgo(toMillis(shop.lastConfirmedAt) ?? toMillis(shop.createdAt), now);
+        return shop.lastConfirmedAt
+            ? {status, label: `⏳ Last confirmed ${ago} — still accurate?`}
+            : {status, label: `⏳ Added ${ago} — never confirmed`};
+    }
+    return {status, label: 'Not yet confirmed by the community'};
+};
+
+/**
+ * Computes the materialized counter updates a report applies to its shop
+ * document. Timestamps are returned as epoch millis; the service layer
+ * converts them to Dates for Firestore.
+ * @param {Object} shop - Current shop document data
+ * @param {Object} report - {type: 'confirm'|'dispute', onSite: boolean, now?: number}
+ * @returns {Object} Field updates for the shop document
+ */
+export const computeShopUpdateForReport = (shop, {type, onSite = false, now = Date.now()}) => {
+    const confirmCount = (shop && shop.confirmCount) || 0;
+    const disputeCount = (shop && shop.disputeCount) || 0;
+
+    if (type === 'confirm') {
+        const update = {
+            lastConfirmedAt: now,
+            confirmCount: confirmCount + 1,
+        };
+        if (onSite) {
+            // Being at the counter outweighs remote disputes
+            update.lastOnSiteConfirmedAt = now;
+            update.disputeCount = 0;
+            update.lastDisputeOnSite = false;
+        }
+        return update;
+    }
+
+    if (type === 'dispute') {
+        return {
+            disputeCount: disputeCount + 1,
+            lastDisputedAt: now,
+            lastDisputeOnSite: Boolean(onSite || (shop && shop.lastDisputeOnSite)),
+        };
+    }
+
+    throw new Error(`Unknown report type: ${type}`);
+};


### PR DESCRIPTION
## Summary

Implements the trust/consensus model we discussed: shops carry a stream of community **reports** instead of a single last-writer-wins value, the UI shows *why* data is trusted, and using the app doubles as contributing to it.

> **Stacked on #14** (both touch `HomeScreen`/`ShopCard`/`ThemeStyles`). Merge #14 first — GitHub will retarget this PR to `main` automatically.

### What users see

- **Shop detail overlay** gets a trust row: a status line (`✓ Confirmed 2w ago · 3 confirmations`, `⏳ Last confirmed 4mo ago — still accurate?`, `⚠ Recent reports say this info may have changed`) plus two one-tap actions: **Still accurate** and **Report a change**.
- **Report a change** opens a small modal asking what the brand/upcharge actually is; suggestions are stored on the report for admin review — disputes never edit the listing directly.
- **Shop cards** get a compact freshness badge (`✓ 2w` / `⏳ 4mo` / `⚠ disputed`).
- The open shop overlay now refreshes from live snapshots, so a confirmation reflects immediately.

### Consensus rules (`utils/reportLogic.js`, pure + unit-tested)

- Confirm → refreshes the freshness clock, increments `confirmCount`
- Confirm **on site** (within 150 m, using the existing geo utils) → also clears standing disputes; being at the counter outweighs remote reports
- Dispute → increments `disputeCount`; **2 disputes or 1 on-site dispute** flips the shop to disputed
- Freshness window: 90 days; older unconfirmed data displays as stale

### Data model

`coffee_shops/{shopId}/reports/{userId}` — one live report per user per shop (doc id = uid), with a 24 h same-type cooldown. Consensus counters (`lastConfirmedAt`, `confirmCount`, `disputeCount`, …) are materialized onto the shop doc in the same batch, so reads stay a single document. Full write-up in [`COMMUNITY_REPORTS.md`](./COMMUNITY_REPORTS.md).

### ⚠ Action needed before this ships

**Firestore security rules must be updated** (rules live in the Firebase console, not this repo). The required rules are in `COMMUNITY_REPORTS.md` — most importantly, community shop-doc updates must be restricted to the consensus counter fields so a report can never rewrite a shop's displayed data.

### Known v1 simplifications (documented in the .md)

- Consensus is computed client-side; rules bound the blast radius, but server-side aggregation (Cloud Function) is the upgrade path.
- `confirmCount` counts confirmations, not unique confirmers.
- No dedicated admin "disputed queue" yet — disputed shops are flagged visually and suggestions live on the reports.

## Test plan

- [x] 34 unit assertions on the consensus logic: timestamp shape handling (Firestore Timestamp/Date/number), on-site radius, status derivation incl. dispute thresholds, time-ago formatting, status labels, and all counter transitions
- [x] All six modified/new files parse cleanly (babel JSX parse)
- [ ] On device: confirm/dispute round-trip against Firestore, cooldown behavior, badge rendering in both themes
- [ ] Apply the security rules from `COMMUNITY_REPORTS.md` in the Firebase console
