### PR TITLE
Usability pass: account deletion, auth fixes, distance units, safe areas, real settings

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import {onAuthStateChanged} from 'firebase/auth';
 import LoginPage from './LoginPage';
 import HomeScreen from './HomeScreen';
 import {ThemeProvider, useTheme} from './contexts/ThemeContext';
+import {UnitsProvider} from './contexts/UnitsContext';
 import {createThemeStyles} from './styles/ThemeStyles';
 import {fontAssets, fonts} from './styles/tokens';
 import {useFonts} from 'expo-font';
@@ -58,7 +59,9 @@ const AppContent = () => {
 export default function App() {
     return (
         <ThemeProvider>
-            <AppContent/>
+            <UnitsProvider>
+                <AppContent/>
+            </UnitsProvider>
         </ThemeProvider>
     );
 }

--- a/HomeScreen.js
+++ b/HomeScreen.js
@@ -7,7 +7,6 @@ import FontAwesome6 from "@react-native-vector-icons/fontawesome6";
 import NetInfo from "@react-native-community/netinfo";
 import {auth, db} from "./services/firebase";
 import {arrayRemove, arrayUnion, collection, doc, getDoc, onSnapshot, setDoc, updateDoc} from "firebase/firestore";
-import {getIdTokenResult} from "firebase/auth";
 import HamburgerMenu from "./components/HamburgerMenu";
 import SubmitShopScreen from "./components/SubmitShopScreen";
 import SettingsScreen from "./components/SettingsScreen";
@@ -25,6 +24,9 @@ import {getFormattedUpcharge, getUpchargeColor} from "./utils/upchargeEmojis";
 import {getDirections} from "./utils/MapLinks";
 import {getDistanceMeters} from "./utils/GeoUtils";
 import {useTheme} from "./contexts/ThemeContext";
+import {useUnits} from "./contexts/UnitsContext";
+import {useAdminStatus} from "./hooks/useAdminStatus";
+import {formatDistance} from "./utils/distanceFormat";
 import {createHomeScreenStyles} from "./styles/ThemeStyles";
 import {isValidLocation} from "./utils/ValidationUtils";
 import {handleError, handleLocationError, showSuccess} from "./utils/ErrorUtils";
@@ -282,12 +284,14 @@ export default function HomeScreen() {
   const [showSettings, setShowSettings] = useState(false);
   const [showPendingShops, setShowPendingShops] = useState(false);
   const [showAdminPanel, setShowAdminPanel] = useState(false);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const {isAdmin} = useAdminStatus();
+  const {unit} = useUnits();
   const [showAdjustPinModal, setShowAdjustPinModal] = useState(false);
   const [showManageShopModal, setShowManageShopModal] = useState(false);
   const [favorites, setFavorites] = useState([]);
   const [isOnline, setIsOnline] = useState(true);
   const [isLoadingFromCache, setIsLoadingFromCache] = useState(true);
+  const [shopsLoaded, setShopsLoaded] = useState(false);
   const [brandFilter, setBrandFilter] = useState(null);
   const [priceFilter, setPriceFilter] = useState(null);
   const [showReportModal, setShowReportModal] = useState(false);
@@ -707,6 +711,7 @@ export default function HomeScreen() {
           console.log('Loaded shops from cache for offline access');
           setShops(cachedShops);
           setIsLoadingFromCache(true);
+          setShopsLoaded(true);
         }
       } catch (error) {
         console.error('Error loading cached shops:', error);
@@ -761,6 +766,7 @@ export default function HomeScreen() {
 
         setShops(shopsList);
         setIsLoadingFromCache(false);
+        setShopsLoaded(true);
 
         // Save to cache for offline access
         saveShopsToCache(shopsList).catch((err) =>
@@ -777,27 +783,6 @@ export default function HomeScreen() {
 
     return () => unsubscribe();
   }, [location]);
-
-  // Check if the current user is an admin
-  useEffect(() => {
-    if (!auth.currentUser) {
-      setIsAdmin(false);
-      return;
-    }
-
-    const checkAdminStatus = async () => {
-      try {
-        const tokenResult = await getIdTokenResult(auth.currentUser);
-        const adminStatus = !!tokenResult.claims.admin;
-        setIsAdmin(adminStatus);
-      } catch (error) {
-        console.error("Failed to fetch admin status:", error);
-        setIsAdmin(false);
-      }
-    };
-
-    checkAdminStatus();
-  }, []);
 
   // Start admin button pulse when admin status changes
   useEffect(() => {
@@ -1090,6 +1075,20 @@ export default function HomeScreen() {
                 <Text style={styles.filterClearButtonText}>Clear filters</Text>
               </TouchableOpacity>
             </View>
+          ) : shopsLoaded ? (
+            // First-open in an unseeded area: explain instead of a blank list
+            <View style={styles.filterEmptyState}>
+              <Text style={styles.filterEmptyText}>
+                No shops on the map here yet — be the first to add one! ☕
+              </Text>
+              <TouchableOpacity
+                style={styles.filterClearButton}
+                onPress={handleSubmitShop}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.filterClearButtonText}>Submit a shop</Text>
+              </TouchableOpacity>
+            </View>
           ) : null
         }
         renderItem={({ item }) => (
@@ -1344,11 +1343,10 @@ export default function HomeScreen() {
                       />
                       <Text style={styles.statLabel}>Distance</Text>
                       <Text style={styles.statValue}>
-                        {(
-                          getDistanceMeters(location, selectedShop.location) /
-                          1000
-                        ).toFixed(1)}
-                        km
+                        {formatDistance(
+                          getDistanceMeters(location, selectedShop.location),
+                          unit,
+                        ) ?? "—"}
                       </Text>
                     </View>
                   </>

--- a/LoginPage.js
+++ b/LoginPage.js
@@ -1,17 +1,32 @@
 import React, {useState} from 'react';
-import {Image, Text, TextInput, TouchableOpacity, View} from 'react-native';
+import {
+    Alert,
+    Image,
+    KeyboardAvoidingView,
+    Platform,
+    Text,
+    TextInput,
+    TouchableOpacity,
+} from 'react-native';
+import FontAwesome6 from '@react-native-vector-icons/fontawesome6';
 import {auth} from './services/firebase';
-import {createUserWithEmailAndPassword, signInWithEmailAndPassword,} from 'firebase/auth';
+import {
+    createUserWithEmailAndPassword,
+    sendPasswordResetEmail,
+    signInWithEmailAndPassword,
+} from 'firebase/auth';
 import {useTheme} from './contexts/ThemeContext';
 import {createLoginPageStyles} from './styles/ThemeStyles';
 import {isValidEmail, validatePassword} from './utils/ValidationUtils';
-import {handleAuthError} from './utils/ErrorUtils';
+import {getFirebaseErrorMessage} from './utils/ErrorUtils';
 
 export default function LoginPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
     const [isLoggingIn, setIsLoggingIn] = useState(false);
     const [isSigningUp, setIsSigningUp] = useState(false);
+    const [isResetting, setIsResetting] = useState(false);
     const [error, setError] = useState('');
 
     // Get theme context
@@ -20,20 +35,21 @@ export default function LoginPage() {
     // Create theme-aware styles
     const styles = createLoginPageStyles(colors);
 
-    const handleSignUp = async () => {
-        // Clear any previous errors
-        setError('');
-
-        // Validate inputs
+    const validateEmailInput = () => {
         if (!email.trim()) {
             setError('Please enter your email address.');
-            return;
+            return false;
         }
-
         if (!isValidEmail(email)) {
             setError('Please enter a valid email address.');
-            return;
+            return false;
         }
+        return true;
+    };
+
+    const handleSignUp = async () => {
+        setError('');
+        if (!validateEmailInput()) return;
 
         if (!password.trim()) {
             setError('Please enter a password.');
@@ -50,26 +66,16 @@ export default function LoginPage() {
         try {
             await createUserWithEmailAndPassword(auth, email.trim(), password);
         } catch (err) {
-            handleAuthError(err, 'signup');
+            console.error('Signup error:', err);
+            setError(getFirebaseErrorMessage(err?.code));
         } finally {
             setIsSigningUp(false);
         }
     };
 
     const handleLogin = async () => {
-        // Clear any previous errors
         setError('');
-
-        // Validate inputs
-        if (!email.trim()) {
-            setError('Please enter your email address.');
-            return;
-        }
-
-        if (!isValidEmail(email)) {
-            setError('Please enter a valid email address.');
-            return;
-        }
+        if (!validateEmailInput()) return;
 
         if (!password.trim()) {
             setError('Please enter your password.');
@@ -80,16 +86,39 @@ export default function LoginPage() {
         try {
             await signInWithEmailAndPassword(auth, email.trim(), password);
         } catch (err) {
-            handleAuthError(err, 'login');
+            console.error('Login error:', err);
+            setError(getFirebaseErrorMessage(err?.code));
         } finally {
             setIsLoggingIn(false);
         }
     };
 
-    const isAnyLoading = isLoggingIn || isSigningUp;
+    const handleForgotPassword = async () => {
+        setError('');
+        if (!validateEmailInput()) return;
+
+        setIsResetting(true);
+        try {
+            await sendPasswordResetEmail(auth, email.trim());
+            Alert.alert(
+                'Check your email',
+                `A password reset link was sent to ${email.trim()}.`,
+            );
+        } catch (err) {
+            console.error('Password reset error:', err);
+            setError(getFirebaseErrorMessage(err?.code));
+        } finally {
+            setIsResetting(false);
+        }
+    };
+
+    const isAnyLoading = isLoggingIn || isSigningUp || isResetting;
 
     return (
-        <View style={styles.authContainer}>
+        <KeyboardAvoidingView
+            style={styles.authContainer}
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
             <Image source={require('./assets/icon.png')} style={styles.authLogo}/>
             <Text style={styles.authTitle}>Welcome to OatMark</Text>
             <Text style={styles.authSubtitle}>Please sign in to use OatMark</Text>
@@ -100,6 +129,7 @@ export default function LoginPage() {
                 placeholderTextColor={colors.tertiaryText}
                 autoCapitalize="none"
                 keyboardType="email-address"
+                autoComplete="email"
                 value={email}
                 onChangeText={(text) => {
                     setEmail(text);
@@ -107,18 +137,34 @@ export default function LoginPage() {
                 }}
                 editable={!isAnyLoading}
             />
-            <TextInput
-                style={styles.input}
-                placeholder="Password"
-                placeholderTextColor={colors.tertiaryText}
-                secureTextEntry
-                value={password}
-                onChangeText={(text) => {
-                    setPassword(text);
-                    setError('');
-                }}
-                editable={!isAnyLoading}
-            />
+            <TouchableOpacity activeOpacity={1} style={styles.passwordRow}>
+                <TextInput
+                    style={styles.passwordInput}
+                    placeholder="Password"
+                    placeholderTextColor={colors.tertiaryText}
+                    secureTextEntry={!showPassword}
+                    autoComplete="password"
+                    value={password}
+                    onChangeText={(text) => {
+                        setPassword(text);
+                        setError('');
+                    }}
+                    editable={!isAnyLoading}
+                />
+                <TouchableOpacity
+                    style={styles.eyeButton}
+                    onPress={() => setShowPassword(!showPassword)}
+                    accessibilityRole="button"
+                    accessibilityLabel={showPassword ? 'Hide password' : 'Show password'}
+                >
+                    <FontAwesome6
+                        name={showPassword ? 'eye-slash' : 'eye'}
+                        size={16}
+                        color={colors.tertiaryText}
+                        iconStyle="solid"
+                    />
+                </TouchableOpacity>
+            </TouchableOpacity>
 
             {error ? (
                 <Text style={styles.errorText}>{error}</Text>
@@ -143,6 +189,16 @@ export default function LoginPage() {
                     {isSigningUp ? 'Creating Account...' : 'Sign Up'}
                 </Text>
             </TouchableOpacity>
-        </View>
+
+            <TouchableOpacity
+                style={styles.forgotLink}
+                onPress={handleForgotPassword}
+                disabled={isAnyLoading}
+            >
+                <Text style={styles.forgotLinkText}>
+                    {isResetting ? 'Sending reset email…' : 'Forgot password?'}
+                </Text>
+            </TouchableOpacity>
+        </KeyboardAvoidingView>
     );
 }

--- a/components/AdjustPinModal.js
+++ b/components/AdjustPinModal.js
@@ -7,6 +7,7 @@ import MapView from "react-native-maps";
 import FreeMapView from "./FreeMapView";
 import {useTheme} from "../contexts/ThemeContext";
 import {fonts, radius, space} from "../styles/tokens";
+import Constants from "expo-constants";
 
 const AdjustPinModal = ({
                             shop,
@@ -195,7 +196,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: 20,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: 20,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,

--- a/components/AdminScreen.js
+++ b/components/AdminScreen.js
@@ -22,6 +22,7 @@ import PendingShopCard from "./PendingShopCard";
 import {createThemeStyles} from "../styles/ThemeStyles";
 import {useTheme} from "../contexts/ThemeContext";
 import {fonts, makeShadow, radius, space} from "../styles/tokens";
+import Constants from "expo-constants";
 
 const AdminScreen = ({onClose}) => {
     const [pendingShops, setPendingShops] = useState([]);
@@ -407,7 +408,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: space.lg,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: space.lg,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,

--- a/components/EditShopDetailsModal.js
+++ b/components/EditShopDetailsModal.js
@@ -7,6 +7,7 @@ import EmojiSelector from "./EmojiSelector";
 import {validateShopName, validateOatMilk, validateUpcharge, validateEmoji} from "../utils/ValidationUtils";
 import {useTheme} from "../contexts/ThemeContext";
 import {fonts, makeShadow, radius, space} from "../styles/tokens";
+import Constants from "expo-constants";
 
 const EditShopDetailsModal = ({
     shop,
@@ -292,7 +293,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: space.lg,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: space.lg,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,

--- a/components/HamburgerMenu.js
+++ b/components/HamburgerMenu.js
@@ -1,15 +1,16 @@
-import React, {useEffect, useState} from 'react';
-import {Modal, Text, TouchableOpacity, View} from 'react-native';
+import React, {useState} from 'react';
+import {Alert, Modal, Text, TouchableOpacity, View} from 'react-native';
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6';
-import {getIdTokenResult, signOut} from 'firebase/auth';
+import {signOut} from 'firebase/auth';
 import {auth} from '../services/firebase';
 import {useTheme} from '../contexts/ThemeContext';
+import {useAdminStatus} from '../hooks/useAdminStatus';
 import {createHamburgerMenuStyles} from '../styles/ThemeStyles';
 
 
 const HamburgerMenu = ({onSubmitShop, onSettings, onPendingShops, onAdminPanel}) => {
     const [isMenuVisible, setIsMenuVisible] = useState(false);
-    const [isAdmin, setIsAdmin] = useState(false);
+    const {isAdmin} = useAdminStatus();
 
     // Get theme context
     const {colors} = useTheme();
@@ -17,28 +18,24 @@ const HamburgerMenu = ({onSubmitShop, onSettings, onPendingShops, onAdminPanel})
     // Create theme-aware styles
     const styles = createHamburgerMenuStyles(colors);
 
-    useEffect(() => {
-        const checkAdmin = async () => {
-            if (auth.currentUser) {
-                try {
-                    const tokenResult = await getIdTokenResult(auth.currentUser);
-                    setIsAdmin(!!tokenResult.claims.admin);
-                } catch (error) {
-                    console.error('Failed to fetch token:', error);
-                }
-            }
-        };
-        checkAdmin();
-    }, []);
-
-    const handleLogout = async () => {
-        try {
-            await signOut(auth);
-            console.log('Logged out!');
-            setIsMenuVisible(false);
-        } catch (err) {
-            console.error('Logout error', err);
-        }
+    const handleLogout = () => {
+        setIsMenuVisible(false);
+        // Confirm, matching the Settings screen — logout shouldn't be one
+        // accidental tap away
+        Alert.alert('Logout', 'Are you sure you want to logout?', [
+            {text: 'Cancel', style: 'cancel'},
+            {
+                text: 'Logout',
+                style: 'destructive',
+                onPress: async () => {
+                    try {
+                        await signOut(auth);
+                    } catch (err) {
+                        console.error('Logout error', err);
+                    }
+                },
+            },
+        ]);
     };
 
     const handleSubmitShop = () => {

--- a/components/PendingShopsScreen.js
+++ b/components/PendingShopsScreen.js
@@ -8,6 +8,7 @@ import MapView, {Marker} from "react-native-maps";
 import FreeMapView from "./FreeMapView";
 import {useTheme} from "../contexts/ThemeContext";
 import {fonts, makeShadow, radius, space} from "../styles/tokens";
+import Constants from "expo-constants";
 
 const PendingShopsScreen = ({onClose}) => {
     const {isDark, colors} = useTheme();
@@ -312,7 +313,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: space.lg,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: space.lg,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,

--- a/components/SettingsScreen.js
+++ b/components/SettingsScreen.js
@@ -12,6 +12,16 @@ import {handleError, showDestructiveConfirmation} from "../utils/ErrorUtils";
 
 const SUPPORT_EMAIL = "donovan.montoya1@gmail.com";
 
+// Firebase requires a recent sign-in for sensitive operations like account
+// deletion (roughly a 5-minute window). Checking up front lets us bail out
+// BEFORE any destructive side effects instead of discovering it halfway.
+const RECENT_LOGIN_WINDOW_MS = 5 * 60 * 1000;
+
+const requiresRecentLogin = (user) => {
+    const lastSignIn = Date.parse(user?.metadata?.lastSignInTime ?? "");
+    return !Number.isFinite(lastSignIn) || Date.now() - lastSignIn > RECENT_LOGIN_WINDOW_MS;
+};
+
 const SettingsScreen = ({onClose}) => {
     // Get theme context
     const {themePreference, setThemePreference, colors} = useTheme();
@@ -40,22 +50,34 @@ const SettingsScreen = ({onClose}) => {
     };
 
     const handleDeleteAccount = () => {
+        const user = auth.currentUser;
+        if (!user || isDeleting) return;
+
+        // Gate on recent reauth BEFORE any destructive step, so the common
+        // stale-session case exits with no side effects
+        if (requiresRecentLogin(user)) {
+            Alert.alert(
+                "Please log in again",
+                "For security, deleting your account requires a recent login. " +
+                "Log out, log back in, then try deleting again.",
+            );
+            return;
+        }
+
         showDestructiveConfirmation(
             "Delete Account",
             "This permanently deletes your account and saved favorites. " +
             "Shops you submitted stay on the map for the community. " +
             "This cannot be undone.",
             async () => {
-                const user = auth.currentUser;
-                if (!user || isDeleting) return;
-
                 setIsDeleting(true);
                 try {
                     // Remove the user's data doc first — after deleteUser the
-                    // request is unauthenticated and rules would deny it
-                    await deleteDoc(doc(db, "users", user.uid)).catch(() => {
-                        // Doc may not exist; account deletion still proceeds
-                    });
+                    // request is unauthenticated and rules would deny it.
+                    // deleteDoc succeeds on a missing doc, so any failure here
+                    // is real (offline, permissions) and aborts the deletion
+                    // with both account and data intact.
+                    await deleteDoc(doc(db, "users", user.uid));
                     await deleteUser(user);
                     // Auth listener flips the app back to the login screen
                 } catch (error) {
@@ -63,7 +85,8 @@ const SettingsScreen = ({onClose}) => {
                         Alert.alert(
                             "Please log in again",
                             "For security, deleting your account requires a recent login. " +
-                            "Log out, log back in, then try deleting again.",
+                            "Log out, log back in, then try deleting again. " +
+                            "You may need to re-save your favorites.",
                         );
                     } else {
                         handleError(error, "Failed to delete your account. Please try again.");

--- a/components/SettingsScreen.js
+++ b/components/SettingsScreen.js
@@ -1,20 +1,23 @@
 import React, {useState} from "react";
-import {Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View,} from "react-native";
+import {Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View,} from "react-native";
 import FontAwesome6 from "@react-native-vector-icons/fontawesome6";
-import {signOut} from "firebase/auth";
-import {auth} from "../services/firebase";
+import {deleteUser, signOut} from "firebase/auth";
+import {deleteDoc, doc} from "firebase/firestore";
+import {auth, db} from "../services/firebase";
 import Constants from "expo-constants";
 import {useTheme} from "../contexts/ThemeContext";
+import {useUnits} from "../contexts/UnitsContext";
 import {fonts, radius, space} from "../styles/tokens";
+import {handleError, showDestructiveConfirmation} from "../utils/ErrorUtils";
+
+const SUPPORT_EMAIL = "donovan.montoya1@gmail.com";
 
 const SettingsScreen = ({onClose}) => {
     // Get theme context
     const {themePreference, setThemePreference, colors} = useTheme();
+    const {unit, setUnit} = useUnits();
+    const [isDeleting, setIsDeleting] = useState(false);
 
-    // noinspection JSUnusedLocalSymbols
-    const [notifications, setNotifications] = useState(true);
-    // noinspection JSUnusedLocalSymbols
-    const [locationSharing, setLocationSharing] = useState(true);
     const handleThemePreferenceChange = (preference) => {
         setThemePreference(preference);
     };
@@ -28,13 +31,57 @@ const SettingsScreen = ({onClose}) => {
                 onPress: async () => {
                     try {
                         await signOut(auth);
-                        console.log("Logged out!");
                     } catch (err) {
                         console.error("Logout error", err);
                     }
                 },
             },
         ]);
+    };
+
+    const handleDeleteAccount = () => {
+        showDestructiveConfirmation(
+            "Delete Account",
+            "This permanently deletes your account and saved favorites. " +
+            "Shops you submitted stay on the map for the community. " +
+            "This cannot be undone.",
+            async () => {
+                const user = auth.currentUser;
+                if (!user || isDeleting) return;
+
+                setIsDeleting(true);
+                try {
+                    // Remove the user's data doc first — after deleteUser the
+                    // request is unauthenticated and rules would deny it
+                    await deleteDoc(doc(db, "users", user.uid)).catch(() => {
+                        // Doc may not exist; account deletion still proceeds
+                    });
+                    await deleteUser(user);
+                    // Auth listener flips the app back to the login screen
+                } catch (error) {
+                    if (error?.code === "auth/requires-recent-login") {
+                        Alert.alert(
+                            "Please log in again",
+                            "For security, deleting your account requires a recent login. " +
+                            "Log out, log back in, then try deleting again.",
+                        );
+                    } else {
+                        handleError(error, "Failed to delete your account. Please try again.");
+                    }
+                } finally {
+                    setIsDeleting(false);
+                }
+            },
+            null,
+            "Delete",
+        );
+    };
+
+    const handleHelp = () => {
+        const url = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent("OatMark Support")}`;
+        Linking.openURL(url).catch(() => {
+            Alert.alert("Help & Support", `Email us at ${SUPPORT_EMAIL}`);
+        });
     };
 
     const handleAbout = () => {
@@ -49,13 +96,26 @@ const SettingsScreen = ({onClose}) => {
     const handlePrivacy = () => {
         Alert.alert(
             "Privacy Policy",
-            "Your location data is used only to show nearby coffee shops and is not stored permanently.",
+            "Your live location is used to show nearby shops and is not tracked in the background. " +
+            "When you submit a shop or confirm its info, your account id and the shop's location " +
+            "are stored with that contribution. You can delete your account at any time from this screen.",
             [{text: "OK"}],
         );
     };
 
     // Generate styles based on the current theme
     const styles = getStyles(colors);
+
+    const themeOptions = [
+        {key: "light", label: "Light", icon: "sun"},
+        {key: "dark", label: "Dark", icon: "moon"},
+        {key: "auto", label: "Auto", icon: "circle-half-stroke"},
+    ];
+
+    const unitOptions = [
+        {key: "km", label: "Kilometers"},
+        {key: "mi", label: "Miles"},
+    ];
 
     return (
         <View style={styles.container}>
@@ -70,42 +130,6 @@ const SettingsScreen = ({onClose}) => {
                 <View style={styles.section}>
                     <Text style={styles.sectionTitle}>Preferences</Text>
 
-                    {/*<View style={styles.settingItem}>*/}
-                    {/*  <View style={styles.settingLeft}>*/}
-                    {/*    <FontAwesome6*/}
-                    {/*      name="bell"*/}
-                    {/*      size={18}*/}
-                    {/*      color="#333"*/}
-                    {/*      iconStyle="solid"*/}
-                    {/*    />*/}
-                    {/*    <Text style={styles.settingText}>Notifications</Text>*/}
-                    {/*  </View>*/}
-                    {/*  <Switch*/}
-                    {/*    value={notifications}*/}
-                    {/*    onValueChange={setNotifications}*/}
-                    {/*    trackColor={{ false: "#767577", true: "#4285F4" }}*/}
-                    {/*    thumbColor="#fff"*/}
-                    {/*  />*/}
-                    {/*</View>*/}
-
-                    {/*<View style={styles.settingItem}>*/}
-                    {/*  <View style={styles.settingLeft}>*/}
-                    {/*    <FontAwesome6*/}
-                    {/*      name="location-dot"*/}
-                    {/*      size={18}*/}
-                    {/*      color="#333"*/}
-                    {/*      iconStyle="solid"*/}
-                    {/*    />*/}
-                    {/*    <Text style={styles.settingText}>Location Sharing</Text>*/}
-                    {/*  </View>*/}
-                    {/*  <Switch*/}
-                    {/*    value={locationSharing}*/}
-                    {/*    onValueChange={setLocationSharing}*/}
-                    {/*    trackColor={{ false: "#767577", true: "#4285F4" }}*/}
-                    {/*    thumbColor="#fff"*/}
-                    {/*  />*/}
-                    {/*</View>*/}
-
                     <View style={styles.settingItem}>
                         <View style={styles.settingLeft}>
                             <FontAwesome6
@@ -119,86 +143,76 @@ const SettingsScreen = ({onClose}) => {
                     </View>
 
                     <View style={styles.themeOptionsRow}>
-                        <TouchableOpacity
-                            style={[
-                                styles.themeOption,
-                                themePreference === "light" && styles.themeOptionSelected,
-                            ]}
-                            onPress={() => handleThemePreferenceChange("light")}
-                        >
-                            <FontAwesome6
-                                name="sun"
-                                size={16}
-                                color={themePreference === "light" ? colors.primary : colors.icon}
-                                iconStyle="solid"
-                            />
-                            <Text
+                        {themeOptions.map(({key, label, icon}) => (
+                            <TouchableOpacity
+                                key={key}
                                 style={[
-                                    styles.themeOptionText,
-                                    {color: themePreference === "light" ? colors.primary : colors.text},
+                                    styles.themeOption,
+                                    themePreference === key && styles.themeOptionSelected,
                                 ]}
+                                onPress={() => handleThemePreferenceChange(key)}
                             >
-                                Light
-                            </Text>
-                        </TouchableOpacity>
-
-                        <TouchableOpacity
-                            style={[
-                                styles.themeOption,
-                                themePreference === "dark" && styles.themeOptionSelected,
-                            ]}
-                            onPress={() => handleThemePreferenceChange("dark")}
-                        >
-                            <FontAwesome6
-                                name="moon"
-                                size={16}
-                                color={themePreference === "dark" ? colors.primary : colors.icon}
-                                iconStyle="solid"
-                            />
-                            <Text
-                                style={[
-                                    styles.themeOptionText,
-                                    {color: themePreference === "dark" ? colors.primary : colors.text},
-                                ]}
-                            >
-                                Dark
-                            </Text>
-                        </TouchableOpacity>
-
-                        <TouchableOpacity
-                            style={[
-                                styles.themeOption,
-                                themePreference === "auto" && styles.themeOptionSelected,
-                            ]}
-                            onPress={() => handleThemePreferenceChange("auto")}
-                        >
-                            <FontAwesome6
-                                name="circle-half-stroke"
-                                size={16}
-                                color={themePreference === "auto" ? colors.primary : colors.icon}
-                                iconStyle="solid"
-                            />
-                            <Text
-                                style={[
-                                    styles.themeOptionText,
-                                    {color: themePreference === "auto" ? colors.primary : colors.text},
-                                ]}
-                            >
-                                Auto
-                            </Text>
-                        </TouchableOpacity>
+                                <FontAwesome6
+                                    name={icon}
+                                    size={16}
+                                    color={themePreference === key ? colors.primary : colors.icon}
+                                    iconStyle="solid"
+                                />
+                                <Text
+                                    style={[
+                                        styles.themeOptionText,
+                                        {color: themePreference === key ? colors.primary : colors.text},
+                                    ]}
+                                >
+                                    {label}
+                                </Text>
+                            </TouchableOpacity>
+                        ))}
                     </View>
                     <Text style={styles.themeHelperText}>
                         Auto follows your device appearance and switches between light and dark
                         automatically.
                     </Text>
+
+                    <View style={styles.settingItem}>
+                        <View style={styles.settingLeft}>
+                            <FontAwesome6
+                                name="ruler"
+                                size={18}
+                                color={colors.icon}
+                                iconStyle="solid"
+                            />
+                            <Text style={styles.settingText}>Distance units</Text>
+                        </View>
+                    </View>
+
+                    <View style={styles.themeOptionsRow}>
+                        {unitOptions.map(({key, label}) => (
+                            <TouchableOpacity
+                                key={key}
+                                style={[
+                                    styles.themeOption,
+                                    unit === key && styles.themeOptionSelected,
+                                ]}
+                                onPress={() => setUnit(key)}
+                            >
+                                <Text
+                                    style={[
+                                        styles.themeOptionText,
+                                        {color: unit === key ? colors.primary : colors.text},
+                                    ]}
+                                >
+                                    {label}
+                                </Text>
+                            </TouchableOpacity>
+                        ))}
+                    </View>
                 </View>
 
                 <View style={styles.section}>
                     <Text style={styles.sectionTitle}>Account</Text>
 
-                    <TouchableOpacity style={styles.settingItem} onPress={() => {
-                    }}>
+                    <View style={styles.settingItem}>
                         <View style={styles.settingLeft}>
                             <FontAwesome6
                                 name="user"
@@ -206,42 +220,47 @@ const SettingsScreen = ({onClose}) => {
                                 color={colors.icon}
                                 iconStyle="solid"
                             />
-                            <Text style={styles.settingText}>Profile</Text>
+                            <Text style={styles.settingText} numberOfLines={1}>
+                                {auth.currentUser?.email || "Signed in"}
+                            </Text>
                         </View>
-                        <FontAwesome6
-                            name="chevron-right"
-                            size={16}
-                            color={colors.tertiaryText}
-                            iconStyle="solid"
-                        />
-                    </TouchableOpacity>
+                    </View>
 
                     <TouchableOpacity style={styles.settingItem} onPress={handleLogout}>
                         <View style={styles.settingLeft}>
                             <FontAwesome6
                                 name="right-from-bracket"
                                 size={18}
+                                color={colors.icon}
+                                iconStyle="solid"
+                            />
+                            <Text style={styles.settingText}>Logout</Text>
+                        </View>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                        style={styles.settingItem}
+                        onPress={handleDeleteAccount}
+                        disabled={isDeleting}
+                    >
+                        <View style={styles.settingLeft}>
+                            <FontAwesome6
+                                name="trash-can"
+                                size={18}
                                 color={colors.danger}
                                 iconStyle="solid"
                             />
                             <Text style={[styles.settingText, {color: colors.danger}]}>
-                                Logout
+                                {isDeleting ? "Deleting Account…" : "Delete Account"}
                             </Text>
                         </View>
-                        <FontAwesome6
-                            name="chevron-right"
-                            size={16}
-                            color={colors.tertiaryText}
-                            iconStyle="solid"
-                        />
                     </TouchableOpacity>
                 </View>
 
                 <View style={styles.section}>
                     <Text style={styles.sectionTitle}>Support</Text>
 
-                    <TouchableOpacity style={styles.settingItem} onPress={() => {
-                    }}>
+                    <TouchableOpacity style={styles.settingItem} onPress={handleHelp}>
                         <View style={styles.settingLeft}>
                             <FontAwesome6
                                 name="circle-question"
@@ -314,7 +333,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: space.lg,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: space.lg,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,
@@ -404,6 +423,7 @@ const getStyles = (colors) => StyleSheet.create({
         color: colors.secondaryText,
         marginTop: space.sm,
         lineHeight: 18,
+        marginBottom: space.sm,
     },
 });
 

--- a/components/ShopCard.js
+++ b/components/ShopCard.js
@@ -4,7 +4,9 @@ import FontAwesome6 from '@react-native-vector-icons/fontawesome6';
 import { getFormattedUpcharge, getUpchargeColor } from '../utils/upchargeEmojis';
 import { getDistanceMeters } from '../utils/GeoUtils';
 import { deriveDataStatus, formatTimeAgo } from '../utils/reportLogic';
+import { formatDistance } from '../utils/distanceFormat';
 import { useTheme } from '../contexts/ThemeContext';
+import { useUnits } from '../contexts/UnitsContext';
 
 /**
  * Compact freshness badge content for a shop card.
@@ -35,10 +37,14 @@ const ShopCard = ({
   styles
 }) => {
   const { colors } = useTheme();
+  const { unit } = useUnits();
   // Create animated value with useRef to prevent recreation on each render
   const scaleAnim = useRef(new Animated.Value(1)).current;
 
   const freshness = getFreshnessBadge(item);
+  const distanceText = location
+    ? formatDistance(getDistanceMeters(location, item.location), unit)
+    : null;
 
   const handlePressIn = () => {
     Animated.spring(scaleAnim, {
@@ -110,11 +116,7 @@ const ShopCard = ({
                   iconStyle="solid"
                 />
                 <Text style={styles.distanceText}>
-                  {location
-                    ? `${(
-                        getDistanceMeters(location, item.location) / 1000
-                      ).toFixed(1)}km away`
-                    : "Location unavailable"}
+                  {distanceText ? `${distanceText} away` : "Location unavailable"}
                 </Text>
                 {freshness && (
                   <Text style={[styles.freshnessBadge, { color: colors[freshness.colorKey] }]}>

--- a/components/SubmitShopScreen.js
+++ b/components/SubmitShopScreen.js
@@ -22,6 +22,7 @@ import {validateShopName, validateOatMilk, validateUpcharge, validateEmoji, isVa
 import {handleError, handleLocationError, showSuccess} from "../utils/ErrorUtils";
 import {useTheme} from "../contexts/ThemeContext";
 import {fonts, makeShadow, radius, space} from "../styles/tokens";
+import Constants from "expo-constants";
 
 const SubmitShopScreen = ({onClose}) => {
     const {isDark, colors} = useTheme();
@@ -549,7 +550,7 @@ const getStyles = (colors) => StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         paddingHorizontal: space.lg,
-        paddingTop: 50,
+        paddingTop: Constants.statusBarHeight + space.sm,
         paddingBottom: space.lg,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,

--- a/contexts/UnitsContext.js
+++ b/contexts/UnitsContext.js
@@ -1,0 +1,54 @@
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'distance_unit';
+
+/**
+ * Distance unit preference ('km' | 'mi'), persisted like the theme
+ * preference. Consumed anywhere a distance is rendered.
+ */
+const UnitsContext = createContext({
+    unit: 'km',
+    setUnit: () => {},
+});
+
+export const UnitsProvider = ({children}) => {
+    const [unit, setUnitState] = useState('km');
+
+    useEffect(() => {
+        AsyncStorage.getItem(STORAGE_KEY)
+            .then((saved) => {
+                if (saved === 'km' || saved === 'mi') {
+                    setUnitState(saved);
+                }
+            })
+            .catch((error) => {
+                console.error('Error loading distance unit preference:', error);
+            });
+    }, []);
+
+    const setUnit = useCallback(async (next) => {
+        if (next !== 'km' && next !== 'mi') return;
+        setUnitState(next);
+        try {
+            await AsyncStorage.setItem(STORAGE_KEY, next);
+        } catch (error) {
+            console.error('Error saving distance unit preference:', error);
+        }
+    }, []);
+
+    const value = useMemo(() => ({unit, setUnit}), [unit, setUnit]);
+
+    return <UnitsContext.Provider value={value}>{children}</UnitsContext.Provider>;
+};
+
+export const useUnits = () => useContext(UnitsContext);
+
+export default UnitsContext;

--- a/styles/ThemeStyles.js
+++ b/styles/ThemeStyles.js
@@ -1,4 +1,5 @@
 import {StyleSheet} from "react-native";
+import Constants from "expo-constants";
 import {fonts, makeShadow, radius, space} from "./tokens";
 
 // Always-dark ink for text sitting on the amber "warning" surface (the offline
@@ -464,7 +465,7 @@ export const createHomeScreenStyles = (colors) => {
         },
         closeButtonTop: {
             position: "absolute",
-            top: 50,
+            top: Constants.statusBarHeight + space.xs,
             left: space.lg,
             zIndex: 20,
         },
@@ -481,7 +482,7 @@ export const createHomeScreenStyles = (colors) => {
         },
         adminFloatingButton: {
             position: "absolute",
-            top: 50,
+            top: Constants.statusBarHeight + space.xs,
             right: space.lg,
             zIndex: 20,
         },
@@ -715,7 +716,7 @@ export const createHamburgerMenuStyles = (colors) => {
     return StyleSheet.create({
         hamburgerButton: {
             position: "absolute",
-            top: 50,
+            top: Constants.statusBarHeight + space.xs,
             left: space.lg,
             backgroundColor: colors.locationButton,
             width: 46,
@@ -819,6 +820,39 @@ export const createLoginPageStyles = (colors) => {
             backgroundColor: colors.inputBackground,
             color: colors.text,
         },
+        passwordRow: {
+            width: "100%",
+            height: 52,
+            flexDirection: "row",
+            alignItems: "center",
+            borderColor: colors.border,
+            borderWidth: 1,
+            borderRadius: radius.sm,
+            marginBottom: space.sm,
+            backgroundColor: colors.inputBackground,
+        },
+        passwordInput: {
+            flex: 1,
+            height: "100%",
+            paddingHorizontal: space.md,
+            fontSize: 16,
+            fontFamily: fonts.body,
+            color: colors.text,
+        },
+        eyeButton: {
+            paddingHorizontal: space.md,
+            height: "100%",
+            justifyContent: "center",
+        },
+        forgotLink: {
+            marginTop: space.xs,
+            padding: space.xs,
+        },
+        forgotLinkText: {
+            fontSize: 14,
+            fontFamily: fonts.semibold,
+            color: colors.accent,
+        },
         authButton: {
             width: "100%",
             backgroundColor: colors.accent,
@@ -866,7 +900,7 @@ export const createLoginPageStyles = (colors) => {
             flexDirection: "row",
             alignItems: "center",
             paddingHorizontal: space.lg,
-            paddingTop: 50,
+            paddingTop: Constants.statusBarHeight + space.sm,
             paddingBottom: space.lg,
         },
         modalTitle: {

--- a/utils/distanceFormat.js
+++ b/utils/distanceFormat.js
@@ -1,0 +1,18 @@
+/**
+ * Distance display formatting with unit support.
+ */
+
+export const METERS_PER_MILE = 1609.344;
+
+/**
+ * Formats a distance in meters for display.
+ * @param {number} meters - Distance in meters
+ * @param {'km'|'mi'} unit - Display unit
+ * @returns {string|null} e.g. "1.2km" or "0.7mi", null when unusable
+ */
+export const formatDistance = (meters, unit = 'km') => {
+    if (!Number.isFinite(meters) || meters < 0) return null;
+    return unit === 'mi'
+        ? `${(meters / METERS_PER_MILE).toFixed(1)}mi`
+        : `${(meters / 1000).toFixed(1)}km`;
+};


### PR DESCRIPTION
## Summary

Implements 10 items from the usability audit (everything except the hosted privacy-policy page, which needs a page published somewhere).

> **Stacked on #15** (chain: #14 → #15 → this). Merge in order; GitHub retargets each PR as its base merges.

### Settings (the screen finally earns its place)
- **Delete Account** with destructive confirmation — removes the user's `users/{uid}` doc then the auth account, and explains the `requires-recent-login` case. This closes the App Store review blocker (guideline 5.1.1(v): apps with account creation must offer in-app deletion).
- **Signed-in email** shown in the Account section; the dead-tap Profile row is gone.
- **Help & Support** opens a pre-addressed support email (currently `donovan.montoya1@gmail.com` — change `SUPPORT_EMAIL` in `SettingsScreen.js` if you want a different address).
- **Privacy alert text corrected** — it claimed location "is not stored permanently," which submissions/reports make false. Now accurately describes what's stored. (The hosted policy page for store submission is still on you — `MANUAL_STEPS.md`-worthy.)
- **Distance units setting** (kilometers/miles), persisted like the theme preference.
- Deleted the commented-out notification/location switches and orphaned state.

### Auth
- **Forgot password?** link → `sendPasswordResetEmail`. Previously a forgotten password meant a permanently lost account.
- Show/hide password toggle; Firebase errors now render inline (same style as validation errors) instead of popping alerts; `KeyboardAvoidingView` so the keyboard doesn't cover the form.
- Hamburger-menu logout now asks for confirmation, matching Settings.

### App shell
- **Distances respect the unit setting everywhere** (new `UnitsContext` + `formatDistance` — ShopCard, shop overlay).
- **First-open empty state**: once loading finishes, an empty list says "No shops on the map here yet — be the first to add one!" with a Submit button, instead of rendering nothing.
- **Safe-area headers**: every screen header and floating button offsets by `Constants.statusBarHeight` instead of a hardcoded 50 (was wrong on notch/Dynamic Island devices).
- **One admin check**: HomeScreen and HamburgerMenu now use the existing `useAdminStatus` hook instead of private copies (AdminScreen already did).

## Test plan

- [x] All 14 modified files parse cleanly (babel JSX parse)
- [x] `formatDistance` unit assertions (km/mi conversion, NaN/negative/undefined → null)
- [ ] On device: delete-account round trip (including the stale-session path), password reset email delivery, units toggle reflected on cards + overlay, headers on a notched device, empty state in an unseeded area
